### PR TITLE
If output is YAML, codecs not needed

### DIFF
--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -35,6 +35,8 @@ def write_extraction(results: ExtractionResult, output: BytesIO, output_format: 
         output = codecs.getwriter("utf-8")(output)
         exporter = MarkdownExporter()
         exporter.export(results, output)
+    elif output_format == "yaml":
+        output.write(dump_minimal_yaml(results))
     else:
         output = codecs.getwriter("utf-8")(output)
         output.write(dump_minimal_yaml(results))


### PR DESCRIPTION
If `output_format == "yaml"` , the line `output = codecs.getwriter("utf-8")(output)` prevents `output.write(dump_minimal_yaml(results))` to dump the results giving the error: `TypeError: write() argument must be str, not bytes` .

This patch fixes that issue.