### PR TITLE
Playing around: adding a  phenotype extractor

### DIFF
--- a/src/ontogpt/templates/phenotype.py
+++ b/src/ontogpt/templates/phenotype.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+from datetime import datetime, date
+from enum import Enum
+from typing import List, Dict, Optional, Any, Union, Literal
+from pydantic import BaseModel as BaseModel, Field
+from linkml_runtime.linkml_model import Decimal
+
+metamodel_version = "None"
+version = "None"
+
+class WeakRefShimBaseModel(BaseModel):
+   __slots__ = '__weakref__'
+    
+class ConfiguredBaseModel(WeakRefShimBaseModel,
+                validate_assignment = True, 
+                validate_all = True, 
+                underscore_attrs_are_private = True, 
+                extra = 'forbid', 
+                arbitrary_types_allowed = True):
+    pass                    
+
+
+class Trait(ConfiguredBaseModel):
+    
+    quality: Optional[str] = Field(None, description="""the phenotypic quality exibited by the phenotype""")
+    anatomical_entity: Optional[str] = Field(None, description="""the name of the disease that is treated.""")
+    chemical_entity: Optional[str] = Field(None, description="""semicolon-separated list of treatment to adverse effect associations, e.g. Imatinib*nausea""")
+    
+
+
+class ExtractionResult(ConfiguredBaseModel):
+    """
+    A result of extracting knowledge on text
+    """
+    input_id: Optional[str] = Field(None)
+    input_title: Optional[str] = Field(None)
+    input_text: Optional[str] = Field(None)
+    raw_completion_output: Optional[str] = Field(None)
+    prompt: Optional[str] = Field(None)
+    extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
+    named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
+    
+
+
+class NamedEntity(ConfiguredBaseModel):
+    
+    id: Optional[str] = Field(None, description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Quality(NamedEntity):
+    
+    id: Optional[str] = Field(None, description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class ChemicalEntity(NamedEntity):
+    
+    id: Optional[str] = Field(None, description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class AnatomicalEntity(NamedEntity):
+    
+    id: Optional[str] = Field(None, description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class CompoundExpression(ConfiguredBaseModel):
+    
+    None
+    
+
+
+class Triple(CompoundExpression):
+    """
+    Abstract parent for Relation Extraction tasks
+    """
+    subject: Optional[str] = Field(None)
+    predicate: Optional[str] = Field(None)
+    object: Optional[str] = Field(None)
+    qualifier: Optional[str] = Field(None, description="""A qualifier for the statements, e.g. \"NOT\" for negation""")
+    subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
+    object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
+    
+
+
+class TextWithTriples(ConfiguredBaseModel):
+    
+    publication: Optional[Publication] = Field(None)
+    triples: Optional[List[Triple]] = Field(default_factory=list)
+    
+
+
+class RelationshipType(NamedEntity):
+    
+    id: Optional[str] = Field(None, description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Publication(ConfiguredBaseModel):
+    
+    id: Optional[str] = Field(None, description="""The publication identifier""")
+    title: Optional[str] = Field(None, description="""The title of the publication""")
+    abstract: Optional[str] = Field(None, description="""The abstract of the publication""")
+    combined_text: Optional[str] = Field(None)
+    full_text: Optional[str] = Field(None, description="""The full text of the publication""")
+    
+
+
+class AnnotatorResult(ConfiguredBaseModel):
+    
+    subject_text: Optional[str] = Field(None)
+    object_id: Optional[str] = Field(None)
+    object_text: Optional[str] = Field(None)
+    
+
+
+
+# Update forward refs
+# see https://pydantic-docs.helpmanual.io/usage/postponed_annotations/
+Trait.update_forward_refs()
+ExtractionResult.update_forward_refs()
+NamedEntity.update_forward_refs()
+Quality.update_forward_refs()
+ChemicalEntity.update_forward_refs()
+AnatomicalEntity.update_forward_refs()
+CompoundExpression.update_forward_refs()
+Triple.update_forward_refs()
+TextWithTriples.update_forward_refs()
+RelationshipType.update_forward_refs()
+Publication.update_forward_refs()
+AnnotatorResult.update_forward_refs()
+

--- a/src/ontogpt/templates/phenotype.yaml
+++ b/src/ontogpt/templates/phenotype.yaml
@@ -22,17 +22,24 @@ classes:
   Trait:
     tree_root: true
     attributes:
+    
       quality:
-        description: the phenotypic quality exibited by the phenotype
+        description: The property being measured, or changes in this property, for example, amount, level, increased amount, decreased concentration
+        annotations:
+          prompt.example: amount, level, increased amount, decreased concentration
         range: Quality
 
       anatomical_entity:
-        description: The anatomical entity that the chemical entity is measured in
+        description: The anatomical location that the chemical entity is measured in
         range: AnatomicalEntity
+        annotations:
+          prompt.example: liver, heart, brain, finger
 
       chemical_entity:
-        description: The chemical entity that is affected by the phenotype
+        description: The chemical entity that is being measured
         range: ChemicalEntity
+        annotations:
+          prompt.example: lysine, metabolite
 
 
   Quality:
@@ -48,7 +55,7 @@ classes:
       - CHEBI
       - PR
     annotations:
-      annotators: sqlite:obo:chebi, sqlite:obo:pr
+      annotators: sqlite:obo:chebi
 
   AnatomicalEntity:
     is_a: NamedEntity

--- a/src/ontogpt/templates/phenotype.yaml
+++ b/src/ontogpt/templates/phenotype.yaml
@@ -1,0 +1,59 @@
+id: http://w3id.org/ontogpt/eq
+name: eq-template
+title: EQ Template
+description: >-
+  A template for Computational Phenotypes
+license: https://creativecommons.org/publicdomain/zero/1.0/
+prefixes:
+  linkml: https://w3id.org/linkml/
+  phenotype: http://w3id.org/ontogpt/phenotype/
+keywords:
+  - phenotype
+  - traits
+
+default_prefix: phenotype
+default_range: string
+
+imports:
+  - linkml:types
+  - core
+
+classes:
+  Trait:
+    tree_root: true
+    attributes:
+      quality:
+        description: the phenotypic quality exibited by the phenotype
+        range: Quality
+
+      anatomical_entity:
+        description: The anatomical entity that the chemical entity is measured in
+        range: AnatomicalEntity
+
+      chemical_entity:
+        description: The chemical entity that is affected by the phenotype
+        range: ChemicalEntity
+
+
+  Quality:
+    is_a: NamedEntity
+    id_prefixes:
+      - PATO
+    annotations:
+      annotators: sqlite:obo:pato
+
+  ChemicalEntity:
+    is_a: NamedEntity
+    id_prefixes:
+      - CHEBI
+      - PR
+    annotations:
+      annotators: sqlite:obo:chebi, sqlite:obo:pr
+
+  AnatomicalEntity:
+    is_a: NamedEntity
+    id_prefixes:
+      - UBERON
+    annotations:
+      annotators: sqlite:obo:uberon
+


### PR DESCRIPTION
@cmungall this may be naive, but I wanted to try ontogpt and go through the motions. 

It is entirely possible that I am not yet understanding all of the thoughts here. I created this trivial phenotype model based on EQ, and I was hoping I could read a definition or label of a term and read it into the structure. I will need your handholding on this :P 

```
ontogpt extract -t phenotype.Trait "increased blood glucose levels"
input_text: increased blood glucose levels
raw_completion_output: "quality: increased blood glucose levels\nanatomical_entity:\
  \ \nchemical_entity:"
prompt: 'Split the following piece of text into fields in the following format:


  quality: <the phenotypic quality exibited by the phenotype>

  anatomical_entity: <the name of the disease that is treated.>

  chemical_entity: <semicolon-separated list of treatment to adverse effect associations,
  e.g. Imatinib*nausea>



  Text:

  increased blood glucose levels


  ===


  '
extracted_object:
  quality: AUTO:increased%20blood%20glucose%20levels
named_entities:
- id: AUTO:increased%20blood%20glucose%20levels
  label: increased blood glucose levels
```