### PR TITLE
Improve dependencies, add a web optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,24 +8,13 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-setuptools = "^65.5.0"
-tox = "^3.25.1"
 click = "^8.1.3"
 importlib = "^1.0.4"
-sphinx = {version = "^5.3.0", extras = ["docs"]}
-sphinx-rtd-theme = {version = "^1.0.0", extras = ["docs"]}
-sphinx-autodoc-typehints = {version = "^1.19.4", extras = ["docs"]}
-sphinx-click = {version = "^4.3.0", extras = ["docs"]}
-myst-parser = {version = "^0.18.1", extras = ["docs"]}
 openai = "^0.27.2"
 oaklib = "^0.1.64"
 gilda = "^0.10.3"
 jsonlines = "^3.1.0"
-fastapi = "^0.88.0"
-uvicorn = "^0.20.0"
-Jinja2 = "^3.1.2"
 python-multipart = "^0.0.5"
-mkdocs-mermaid2-plugin = "^0.6.0"
 linkml-owl = "^0.2.7"
 beautifulsoup4 = "^4.11.1"
 eutils = "^0.6.0"
@@ -43,9 +32,19 @@ aiohttp = "^3.8.4"
 inflection = "^0.5.1"
 linkml-runtime = "^1.4.9"
 nlpcloud = "^1.0.39"
+fastapi = {version = "^0.88.0", optional = true}
+uvicorn = {version = "^0.20.0", optional = true}
+Jinja2 = {version = "^3.1.2", optional = true}
+sphinx = {version = "^5.3.0", extras = ["docs"], optional = true}
+sphinx-rtd-theme = {version = "^1.0.0", extras = ["docs"], optional = true}
+sphinx-autodoc-typehints = {version = "^1.19.4", extras = ["docs"], optional = true}
+sphinx-click = {version = "^4.3.0", extras = ["docs"], optional = true}
+myst-parser = {version = "^0.18.1", extras = ["docs"], optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
+setuptools = "^65.5.0"
+tox = "^3.25.1"
 mkdocs-mermaid2-plugin = "^0.6.0"
 
 [tool.poetry.scripts]
@@ -60,6 +59,11 @@ docs = [
     "sphinx-click",
     "myst-parser"
     ]
+web = [
+    "fastapi",
+    "uvicorn",
+    "Jinja2"
+]
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
@cmungall Improve the dependencies definition by moving some development dependencies to the devDependencies (e.g. tox), and created a new `web` optional dependency bundle to install all dependencies required to run the web service

Mentioned here: https://github.com/monarch-initiative/ontogpt/issues/3