### PR TITLE
Makefile uses all templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TMPRUN =
 PACKAGE = ontogpt
 TEMPLATE_DIR = src/$(PACKAGE)/templates
 EVAL_DIR = src/$(PACKAGE)/evaluation
-TEMPLATES = core gocam mendelian_disease biological_process treatment environmental_sample metagenome_study reaction recipe ontology_class metabolic_process drug ctd halo gene_description_term
+TEMPLATES = $(notdir $(basename $(wildcard $(TEMPLATE_DIR)/*.yaml)))
 ENTRY_CLASSES = recipe.Recipe gocam.GoCamAnnotations reaction.ReactionDocument ctd.ChemicalToDiseaseDocument
 
 all: all_pydantic all_projects update_citation
@@ -12,6 +12,9 @@ all: all_pydantic all_projects update_citation
 all_pydantic: $(patsubst %, $(TEMPLATE_DIR)/%.py, $(TEMPLATES))
 all_projects: $(patsubst %, projects/%, $(TEMPLATES))
 all_docs: $(patsubst %, docs/%/index.md, $(TEMPLATES))
+
+list_templates: $(TEMPLATE_DIR)/*.yaml
+	@echo $(basename $^)
 
 test: unit-test
 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,6 @@ We recommend following an established schema like [BioLink Model](https://github
 
 Place the schema YAML in the directory `src/ontogpt/templates/`.
 
-Add the name of the template to the TEMPLATES list in `project.Makefile`.
-
 Run the `make` command at the top level. This will compile the schema to Python (Pydantic classes).
 
 ### Step 3: Run the command line
@@ -361,7 +359,6 @@ This relies on an existing LLM, and LLMs can be fickle in their responses.
 
 You will need an OpenAI account to use their API. In theory any LLM can be used but in practice the parser is tuned for OpenAI's models.
 
-
-# Acknowledgements
+## Acknowledgements
 
 We gratefully acknowledge [Bosch Research](https://www.bosch.com/research) for their support of this research project.

--- a/project.Makefile
+++ b/project.Makefile
@@ -1,5 +1,0 @@
-# Changing these values will change the behavior of the Makefile.
-TEMPLATE_DIR = src/$(PACKAGE)/templates
-EVAL_DIR = src/$(PACKAGE)/evaluation
-TEMPLATES = core gocam mendelian_disease biological_process treatment environmental_sample metagenome_study reaction recipe ontology_class metabolic_process drug ctd halo gene_description_term
-ENTRY_CLASSES = recipe.Recipe gocam.GoCamAnnotations reaction.ReactionDocument ctd.ChemicalToDiseaseDocument


### PR DESCRIPTION
This should support easier use of custom templates - just drop them in the templates directory and make all.
Holding off on any dynamic compilation for now.

This may not work on mac OS make - not certain the explicit `wildcard` function is there.