### PR TITLE
Fix for doc generation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,5 +40,5 @@ jobs:
     - name: Create local docs
       run: |
         touch docs/.nojekyll
-        make all_docs
-        make gh-deploy
+        poetry run make all_docs
+        poetry run make gh-deploy


### PR DESCRIPTION
`gen-doc` is part of linkml and installed by poetry, so it needs to be called with `poetry run`.