### PR TITLE
Fixed a bug where the 'skip_annotators' option was being ignored

### DIFF
--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -415,7 +415,7 @@ def recipe_extract(url, recipes_urls_file, dictionary, output, output_format, **
     if settings.cache_db:
         ke.client.cache_db_path = settings.cache_db
     if settings.skip_annotators:
-        ke.client.skip_annotators = settings.skip_annotators
+        ke.skip_annotators = settings.skip_annotators
     if dictionary:
         ke.load_dictionary(dictionary)
     ingredients = "\n".join(scraper.ingredients())


### PR DESCRIPTION
This merge request fixes a bug where the annotators were not being skipped even when the 'skip_annotators' option was specified. Specifically, I have corrected the assignment of the skip_annotators option so that its value is now assigned to 'ke.skip_annotators' as intended, instead of being assigned to 'ke.client.skip_annotators'.