### PR TITLE
Fixes for #139

### DIFF
--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -87,7 +87,6 @@ def write_extraction(
     knowledge_engine: KnowledgeEngine = None,
 ):
     """Write results of extraction to a given output stream."""
-
     # Check if this result contains anything writable first
     if results.extracted_object:
         if output_format == "pickle":

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -86,30 +86,34 @@ def write_extraction(
     output_format: str = None,
     knowledge_engine: KnowledgeEngine = None,
 ):
-    if output_format == "pickle":
-        output.write(pickle.dumps(results))
-    elif output_format == "md":
-        output = _as_text_writer(output)
-        exporter = MarkdownExporter()
-        exporter.export(results, output)
-    elif output_format == "html":
-        output = _as_text_writer(output)
-        exporter = HTMLExporter()
-        exporter.export(results, output)
-    elif output_format == "yaml":
-        output = _as_text_writer(output)
-        output.write(dump_minimal_yaml(results))
-    elif output_format == "turtle":
-        output = _as_text_writer(output)
-        exporter = RDFExporter()
-        exporter.export(results, output, knowledge_engine.schemaview)
-    elif output_format == "owl":
-        output = _as_text_writer(output)
-        exporter = OWLExporter()
-        exporter.export(results, output, knowledge_engine.schemaview)
-    else:
-        output = _as_text_writer(output)
-        output.write(dump_minimal_yaml(results))
+    """Write results of extraction to a given output stream."""
+
+    # Check if this result contains anything writable first
+    if results.extracted_object:
+        if output_format == "pickle":
+            output.write(pickle.dumps(results))
+        elif output_format == "md":
+            output = _as_text_writer(output)
+            exporter = MarkdownExporter()
+            exporter.export(results, output)
+        elif output_format == "html":
+            output = _as_text_writer(output)
+            exporter = HTMLExporter()
+            exporter.export(results, output)
+        elif output_format == "yaml":
+            output = _as_text_writer(output)
+            output.write(dump_minimal_yaml(results))
+        elif output_format == "turtle":
+            output = _as_text_writer(output)
+            exporter = RDFExporter()
+            exporter.export(results, output, knowledge_engine.schemaview)
+        elif output_format == "owl":
+            output = _as_text_writer(output)
+            exporter = OWLExporter()
+            exporter.export(results, output, knowledge_engine.schemaview)
+        else:
+            output = _as_text_writer(output)
+            output.write(dump_minimal_yaml(results))
 
 
 inputfile_option = click.option("-i", "--inputfile", help="Path to a file containing input text.")

--- a/src/ontogpt/io/rdf_exporter.py
+++ b/src/ontogpt/io/rdf_exporter.py
@@ -39,7 +39,9 @@ class RDFExporter(Exporter):
         try:
             dmp = rdflib_dumper.dumps(dc_obj, schemaview=schemaview, prefix_map=pm)
             output.write(dmp)
-        except (Exception, ValueError) as e:
+        except (Exception, ValueError) as e:  
+            # Don't really like catching base Exception here,
+            # but that's what rdflib raises
             logging.error(e)
 
 

--- a/src/ontogpt/io/rdf_exporter.py
+++ b/src/ontogpt/io/rdf_exporter.py
@@ -1,4 +1,5 @@
 """RDF convertor."""
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TextIO, Union
@@ -9,6 +10,8 @@ from linkml_runtime.dumpers import rdflib_dumper
 
 from ontogpt.io.exporter import Exporter
 from ontogpt.templates.core import ExtractionResult
+
+# TODO: get URI prefixes from bioregistry
 
 
 @dataclass
@@ -33,8 +36,12 @@ class RDFExporter(Exporter):
         pm = {"_base": "http://example.org/NOPREFIX/"}
         if "AUTO" not in schemaview.schema.prefixes:
             pm["AUTO"] = "http://example.org/AUTO/"
-        dmp = rdflib_dumper.dumps(dc_obj, schemaview=schemaview, prefix_map=pm)
-        output.write(dmp)
+        try:
+            dmp = rdflib_dumper.dumps(dc_obj, schemaview=schemaview, prefix_map=pm)
+            output.write(dmp)
+        except (Exception, ValueError) as e:
+            logging.error(e)
+
 
     def _dataclass_model(self, schemaview: SchemaView):
         schemaview.merge_imports()

--- a/src/ontogpt/io/rdf_exporter.py
+++ b/src/ontogpt/io/rdf_exporter.py
@@ -39,9 +39,10 @@ class RDFExporter(Exporter):
         try:
             dmp = rdflib_dumper.dumps(dc_obj, schemaview=schemaview, prefix_map=pm)
             output.write(dmp)
-        except (Exception, ValueError) as e:  
+        except (Exception) as e:  
             # Don't really like catching base Exception here,
-            # but that's what rdflib raises
+            # but that's what rdflib raises.
+            # Otherwise, catch ValueError
             logging.error(e)
 
 

--- a/src/ontogpt/templates/ibd_literature.yaml
+++ b/src/ontogpt/templates/ibd_literature.yaml
@@ -4,6 +4,17 @@ title: IBD Literature Template
 description: >-
   A template for extracting information from IBD literature
 license: https://creativecommons.org/publicdomain/zero/1.0/
+prefixes:
+  CHEBI: http://purl.obolibrary.org/obo/CHEBI_
+  ECTO: http://purl.obolibrary.org/obo/ECTO_
+  ExO: http://purl.obolibrary.org/obo/ExO_
+  HGNC: http://identifiers.org/hgnc/
+  NCIT: http://purl.obolibrary.org/obo/NCIT_
+  core: http://w3id.org/ontogpt/core/
+  linkml: https://w3id.org/linkml/
+
+default_prefix: ibdlit
+default_range: string
 
 imports:
   - linkml:types

--- a/src/ontogpt/templates/ibd_literature.yaml
+++ b/src/ontogpt/templates/ibd_literature.yaml
@@ -11,6 +11,7 @@ prefixes:
   HGNC: http://identifiers.org/hgnc/
   NCIT: http://purl.obolibrary.org/obo/NCIT_
   core: http://w3id.org/ontogpt/core/
+  ibdlit: http://w3id.org/ontogpt/ibd_literature/
   linkml: https://w3id.org/linkml/
 
 default_prefix: ibdlit


### PR DESCRIPTION
Writing to ttl or owl fails when the `RDFExporter` or `OWLExporter` are passed an `ExtractionResult.extracted_object` of None.
This checks for that condition first.