### PR TITLE
Testing figures template.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PACKAGE = ontogpt
 TEMPLATE_DIR = src/$(PACKAGE)/templates
 EVAL_DIR = src/$(PACKAGE)/evaluation
 TEMPLATES = $(notdir $(basename $(wildcard $(TEMPLATE_DIR)/*.yaml)))
-ENTRY_CLASSES = recipe.Recipe gocam.GoCamAnnotations reaction.ReactionDocument ctd.ChemicalToDiseaseDocument
+ENTRY_CLASSES = recipe.Recipe gocam.GoCamAnnotations reaction.ReactionDocument ctd.ChemicalToDiseaseDocument figure.FigureCaption
 
 all: all_pydantic all_projects
 

--- a/src/ontogpt/templates/figure.py
+++ b/src/ontogpt/templates/figure.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+from datetime import datetime, date
+from enum import Enum
+from typing import List, Dict, Optional, Any, Union
+from pydantic import BaseModel as BaseModel, Field
+from linkml_runtime.linkml_model import Decimal
+import sys
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+
+metamodel_version = "None"
+version = "None"
+
+class WeakRefShimBaseModel(BaseModel):
+   __slots__ = '__weakref__'
+
+class ConfiguredBaseModel(WeakRefShimBaseModel,
+                validate_assignment = True,
+                validate_all = True,
+                underscore_attrs_are_private = True,
+                extra = 'forbid',
+                arbitrary_types_allowed = True,
+                use_enum_values = True):
+    pass
+
+
+class NullDataOptions(str, Enum):
+    
+    
+    UNSPECIFIED_METHOD_OF_ADMINISTRATION = "UNSPECIFIED_METHOD_OF_ADMINISTRATION"
+    
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    
+    NOT_MENTIONED = "NOT_MENTIONED"
+    
+    
+
+class ExtractionResult(ConfiguredBaseModel):
+    """
+    A result of extracting knowledge on text
+    """
+    input_id: Optional[str] = Field(None)
+    input_title: Optional[str] = Field(None)
+    input_text: Optional[str] = Field(None)
+    raw_completion_output: Optional[str] = Field(None)
+    prompt: Optional[str] = Field(None)
+    extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
+    named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
+    
+
+
+class NamedEntity(ConfiguredBaseModel):
+    
+    id: Optional[str] = Field(None, description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class FigureCaption(NamedEntity):
+    """
+    A caption for a figure from a scientific paper. The caption may contain multiple subpanel descriptions.
+    """
+    title: Optional[str] = Field(None, description="""the overall title of the figure caption""")
+    subpanel: Optional[List[SubPanel]] = Field(default_factory=list, description="""a subpanel of the figure""")
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class SubPanel(NamedEntity):
+    """
+    A subcomponent of the overall figure caption.
+    """
+    id: Optional[str] = Field(None, description="""The identifier for this figure subpanel""")
+    text: Optional[str] = Field(None, description="""The text associated with this figure subpanel""")
+    info: Optional[str] = Field(None, description="""any information from the overall figure caption that applies to that subpanel (which may be duplicated across other subpanels).""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class CompoundExpression(ConfiguredBaseModel):
+    
+    None
+    
+
+
+class Triple(CompoundExpression):
+    """
+    Abstract parent for Relation Extraction tasks
+    """
+    subject: Optional[str] = Field(None)
+    predicate: Optional[str] = Field(None)
+    object: Optional[str] = Field(None)
+    qualifier: Optional[str] = Field(None, description="""A qualifier for the statements, e.g. \"NOT\" for negation""")
+    subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
+    object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
+    
+
+
+class TextWithTriples(ConfiguredBaseModel):
+    
+    publication: Optional[Publication] = Field(None)
+    triples: Optional[List[Triple]] = Field(default_factory=list)
+    
+
+
+class RelationshipType(NamedEntity):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Publication(ConfiguredBaseModel):
+    
+    id: Optional[str] = Field(None, description="""The publication identifier""")
+    title: Optional[str] = Field(None, description="""The title of the publication""")
+    abstract: Optional[str] = Field(None, description="""The abstract of the publication""")
+    combined_text: Optional[str] = Field(None)
+    full_text: Optional[str] = Field(None, description="""The full text of the publication""")
+    
+
+
+class AnnotatorResult(ConfiguredBaseModel):
+    
+    subject_text: Optional[str] = Field(None)
+    object_id: Optional[str] = Field(None)
+    object_text: Optional[str] = Field(None)
+    
+
+
+
+# Update forward refs
+# see https://pydantic-docs.helpmanual.io/usage/postponed_annotations/
+ExtractionResult.update_forward_refs()
+NamedEntity.update_forward_refs()
+FigureCaption.update_forward_refs()
+SubPanel.update_forward_refs()
+CompoundExpression.update_forward_refs()
+Triple.update_forward_refs()
+TextWithTriples.update_forward_refs()
+RelationshipType.update_forward_refs()
+Publication.update_forward_refs()
+AnnotatorResult.update_forward_refs()
+

--- a/src/ontogpt/templates/figure.py
+++ b/src/ontogpt/templates/figure.py
@@ -38,6 +38,25 @@ class NullDataOptions(str, Enum):
     
     
 
+class FigureCaption(ConfiguredBaseModel):
+    """
+    A caption for a figure from a scientific paper. The caption may contain multiple subpanel descriptions.
+    """
+    title: Optional[str] = Field(None, description="""the overall title of the figure caption""")
+    subpanel: Optional[List[SubPanel]] = Field(default_factory=list, description="""a subpanel of the figure""")
+    
+
+
+class SubPanel(ConfiguredBaseModel):
+    """
+    A subcomponent of the overall figure caption.
+    """
+    id: Optional[str] = Field(None, description="""The identifier for this figure subpanel""")
+    text: Optional[str] = Field(None, description="""The text associated with this figure subpanel""")
+    info: Optional[str] = Field(None, description="""any information from the overall figure caption that applies to that subpanel (which may be duplicated across other subpanels).""")
+    
+
+
 class ExtractionResult(ConfiguredBaseModel):
     """
     A result of extracting knowledge on text
@@ -55,28 +74,6 @@ class ExtractionResult(ConfiguredBaseModel):
 class NamedEntity(ConfiguredBaseModel):
     
     id: Optional[str] = Field(None, description="""A unique identifier for the named entity""")
-    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
-    
-
-
-class FigureCaption(NamedEntity):
-    """
-    A caption for a figure from a scientific paper. The caption may contain multiple subpanel descriptions.
-    """
-    title: Optional[str] = Field(None, description="""the overall title of the figure caption""")
-    subpanel: Optional[List[SubPanel]] = Field(default_factory=list, description="""a subpanel of the figure""")
-    id: str = Field(..., description="""A unique identifier for the named entity""")
-    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
-    
-
-
-class SubPanel(NamedEntity):
-    """
-    A subcomponent of the overall figure caption.
-    """
-    id: Optional[str] = Field(None, description="""The identifier for this figure subpanel""")
-    text: Optional[str] = Field(None, description="""The text associated with this figure subpanel""")
-    info: Optional[str] = Field(None, description="""any information from the overall figure caption that applies to that subpanel (which may be duplicated across other subpanels).""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
 
@@ -135,10 +132,10 @@ class AnnotatorResult(ConfiguredBaseModel):
 
 # Update forward refs
 # see https://pydantic-docs.helpmanual.io/usage/postponed_annotations/
-ExtractionResult.update_forward_refs()
-NamedEntity.update_forward_refs()
 FigureCaption.update_forward_refs()
 SubPanel.update_forward_refs()
+ExtractionResult.update_forward_refs()
+NamedEntity.update_forward_refs()
 CompoundExpression.update_forward_refs()
 Triple.update_forward_refs()
 TextWithTriples.update_forward_refs()

--- a/src/ontogpt/templates/figure.yaml
+++ b/src/ontogpt/templates/figure.yaml
@@ -40,5 +40,3 @@ classes:
         description: The text associated with this figure subpanel
       info:
         description: any information from the overall figure caption that applies to that subpanel (which may be duplicated across other subpanels).
-    annotations:
-      annotators: sqlite:obo:go

--- a/src/ontogpt/templates/figure.yaml
+++ b/src/ontogpt/templates/figure.yaml
@@ -18,7 +18,6 @@ imports:
 classes:
   FigureCaption:
     tree_root: true
-    is_a: NamedEntity
     description: A caption for a figure from a scientific paper. The caption may contain multiple subpanel descriptions.
     attributes:
       title:
@@ -29,7 +28,6 @@ classes:
         range: SubPanel
 
   SubPanel:
-    is_a: NamedEntity
     description: A subcomponent of the overall figure caption.
     attributes:
       id:

--- a/src/ontogpt/templates/figure.yaml
+++ b/src/ontogpt/templates/figure.yaml
@@ -24,6 +24,10 @@ classes:
         description: the overall title of the figure caption
       subpanel:
         description: a subpanel of the figure
+        annotations:
+          prompt: >-
+            a semicolon separated list of descriptions of every panel in the text. Keep the panel id and text together.
+            for example: "1A: A side view of the foo; 1B: A frontal view of the foo"
         multivalued: true
         range: SubPanel
 

--- a/src/ontogpt/templates/figure.yaml
+++ b/src/ontogpt/templates/figure.yaml
@@ -1,0 +1,44 @@
+id: https://w3id.org/ontogpt/figure
+name: figure-template
+title: Plazi Figure Template
+description: >-
+  A template for Plazi figures and sub-parts
+license: https://creativecommons.org/publicdomain/zero/1.0/
+prefixes:
+  linkml: https://w3id.org/linkml/
+  fig: http://w3id.org/ontogpt/figure-template
+
+default_prefix: fig
+default_range: string
+
+imports:
+  - linkml:types
+  - core
+
+classes:
+  FigureCaption:
+    tree_root: true
+    is_a: NamedEntity
+    description: A caption for a figure from a scientific paper. The caption may contain multiple subpanel descriptions.
+    attributes:
+      title:
+        description: the overall title of the figure caption
+      subpanel:
+        description: a subpanel of the figure
+        multivalued: true
+        range: SubPanel
+
+  SubPanel:
+    is_a: NamedEntity
+    description: A subcomponent of the overall figure caption.
+    attributes:
+      id:
+        description: The identifier for this figure subpanel
+        annotations:
+          prompt.example: 1, 2, A, B, I, II
+      text:
+        description: The text associated with this figure subpanel
+      info:
+        description: any information from the overall figure caption that applies to that subpanel (which may be duplicated across other subpanels).
+    annotations:
+      annotators: sqlite:obo:go


### PR DESCRIPTION
Currently seeing error:

```
jim (figures)$ poetry run ontogpt extract -t figure.FigureCaption -i caption.txt -o caption.yaml
Configuration file exists at /Users/jim/Library/Preferences/pypoetry, reusing this directory.

Consider moving TOML configuration files to /Users/jim/Library/Application Support/pypoetry, as support for the legacy directory will be removed in an upcoming release.
ERROR:root:HuggingFace Hub API key not found. See README.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/jim/Library/Caches/pypoetry/virtualenvs/ontogpt-T28sWqJT-py3.11/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jim/Library/Caches/pypoetry/virtualenvs/ontogpt-T28sWqJT-py3.11/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jim/Library/Caches/pypoetry/virtualenvs/ontogpt-T28sWqJT-py3.11/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jim/Library/Caches/pypoetry/virtualenvs/ontogpt-T28sWqJT-py3.11/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jim/Library/Caches/pypoetry/virtualenvs/ontogpt-T28sWqJT-py3.11/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jim/Documents/Source/ontogpt/src/ontogpt/cli.py", line 298, in extract
    results = ke.extract_from_text(text, target_class_def)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jim/Documents/Source/ontogpt/src/ontogpt/engines/spires_engine.py", line 91, in extract_from_text
    extracted_object = self.parse_completion_payload(raw_text, cls, object=object)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jim/Documents/Source/ontogpt/src/ontogpt/engines/spires_engine.py", line 529, in parse_completion_payload
    self._auto_add_ids(raw, cls)
  File "/Users/jim/Documents/Source/ontogpt/src/ontogpt/engines/spires_engine.py", line 542, in _auto_add_ids
    if slot.range == "uriorcurie" or self.range == "uri":
                                     ^^^^^^^^^^
AttributeError: 'SPIRESEngine' object has no attribute 'range'
```