### PR TITLE
Add option to show prompt

### DIFF
--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -181,6 +181,12 @@ auto_prefix_option = click.option(
     default="AUTO",
     help="Prefix to use for auto-generated classes. Default is AUTO.",
 )
+show_prompt_option = click.option(
+    "--show-prompt/--no-show-prompt",
+    default=False,
+    show_default=True,
+    help="If set, show all prompts passed to model through an API.",
+)
 
 
 @click.group()
@@ -226,6 +232,7 @@ def main(verbose: int, quiet: bool, cache_db: str, skip_annotator):
 @output_format_options
 @use_textract_options
 @auto_prefix_option
+@show_prompt_option
 @click.option(
     "--set-slot-value",
     "-S",
@@ -244,6 +251,7 @@ def extract(
     set_slot_value,
     use_textract,
     model,
+    show_prompt,
     **kwargs,
 ):
     """Extract knowledge from text guided by schema, using SPIRES engine.
@@ -839,6 +847,7 @@ def convert_geneset(input_file, output, output_format, fill, **kwargs):
 @output_option_txt
 @output_format_options
 @model_option
+@show_prompt_option
 @click.option(
     "--resolver", "-r", help="OAK selector for the gene ID resolver. E.g. sqlite:obo:hgnc"
 )
@@ -852,12 +861,6 @@ def convert_geneset(input_file, output, output_format, fill, **kwargs):
     default=True,
     show_default=True,
     help="If set, there must be a unique mappings from labels to IDs",
-)
-@click.option(
-    "--show-prompt/--no-show-prompt",
-    default=True,
-    show_default=True,
-    help="If set, show prompt passed to model",
 )
 @click.option(
     "--input-file",

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -185,7 +185,7 @@ show_prompt_option = click.option(
     "--show-prompt/--no-show-prompt",
     default=False,
     show_default=True,
-    help="If set, show all prompts passed to model through an API.",
+    help="If set, show all prompts passed to model through an API. Use with verbose setting.",
 )
 
 

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -316,7 +316,7 @@ def extract(
         target_class_def = ke.schemaview.get_class(target_class)
     else:
         target_class_def = None
-    results = ke.extract_from_text(text, target_class_def)
+    results = ke.extract_from_text(text=text, cls=target_class_def, show_prompt=show_prompt)
     if set_slot_value:
         for slot_value in set_slot_value:
             slot, value = slot_value.split("=")
@@ -332,8 +332,9 @@ def extract(
 @output_option_wb
 @output_format_options
 @auto_prefix_option
+@show_prompt_option
 @click.argument("entity")
-def generate_extract(model, entity, template, output, output_format, **kwargs):
+def generate_extract(model, entity, template, output, output_format, show_prompt, **kwargs):
     """Generate text and then extract knowledge from it."""
     logging.info(f"Creating for {template}")
 
@@ -354,7 +355,7 @@ def generate_extract(model, entity, template, output, output_format, **kwargs):
         ke = GPT4AllEngine(template=template, model=model_name, **kwargs)
 
     logging.debug(f"Input entity: {entity}")
-    results = ke.generate_and_extract(entity)
+    results = ke.generate_and_extract(entity, show_prompt)
     write_extraction(results, output, output_format, ke)
 
 
@@ -365,6 +366,7 @@ def generate_extract(model, entity, template, output, output_format, **kwargs):
 @output_option_wb
 @output_format_options
 @auto_prefix_option
+@show_prompt_option
 @click.option("--ontology", "-r", help="Ontology to use; use oaklib selector path")
 @click.option("--max-iterations", "-M", default=10, type=click.INT)
 @click.option("--iteration-slot", "-I", multiple=True, help="Slots to iterate over")
@@ -998,7 +1000,7 @@ def enrichment(
 @click.argument("text", nargs=-1)
 def embed(text, context, output, model, output_format, **kwargs):
     """Embed text.
-    
+
     Not currently supported for open models.
     """
     if model:
@@ -1030,7 +1032,7 @@ def embed(text, context, output, model, output_format, **kwargs):
 @click.argument("text", nargs=-1)
 def text_similarity(text, context, output, model, output_format, **kwargs):
     """Embed text.
-    
+
     Not currently supported for open models.
     """
     if model:
@@ -1070,7 +1072,7 @@ def text_similarity(text, context, output, model, output_format, **kwargs):
 @click.argument("text", nargs=-1)
 def text_distance(text, context, output, model, output_format, **kwargs):
     """Embed text and calculate euclidian distance between embeddings.
-    
+
     Not currently supported for open models.
     """
     if model:
@@ -1483,8 +1485,9 @@ def openai_models(**kwargs):
 @model_option
 @output_option_txt
 @output_format_options
+@show_prompt_option
 @click.argument("input")
-def complete(model, input, output, output_format, **kwargs):
+def complete(model, input, output, output_format, show_prompt, **kwargs):
     """Prompt completion."""
     if not model:
         model = DEFAULT_MODEL
@@ -1496,7 +1499,7 @@ def complete(model, input, output, output_format, **kwargs):
 
     if model_source == "OpenAI":
         c = OpenAIClient(model=model_name)
-        results = c.complete(text)
+        results = c.complete(text, show_prompt)
 
     elif model_source == "GPT4All":
         c = set_up_gpt4all_model(modelname=model_name)

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -386,6 +386,7 @@ def iteratively_generate_extract(
     max_iterations,
     clear,
     ontology,
+    show_prompt,
     **kwargs,
 ):
     """Iterate through generate-extract."""
@@ -412,6 +413,7 @@ def iteratively_generate_extract(
     for results in ke.iteratively_generate_and_extract(
         entity,
         db,
+        show_prompt=show_prompt,
         iteration_slots=list(iteration_slot),
         max_iterations=max_iterations,
         adapter=adapter,
@@ -426,13 +428,14 @@ def iteratively_generate_extract(
 @recurse_option
 @output_option_wb
 @output_format_options
+@show_prompt_option
 @click.option(
     "--get-pmc/--no-get-pmc",
     default=False,
     help="Attempt to parse PubMed Central full text(s) instead of abstract(s) alone.",
 )
 @click.argument("pmid")
-def pubmed_extract(model, pmid, template, output, output_format, get_pmc, **kwargs):
+def pubmed_extract(model, pmid, template, output, output_format, get_pmc, show_prompt, **kwargs):
     """Extract knowledge from a single PubMed ID."""
     logging.info(f"Creating for {template}")
 
@@ -460,7 +463,7 @@ def pubmed_extract(model, pmid, template, output, output_format, get_pmc, **kwar
         textlist = pmc.text(pmid)
     for text in textlist:
         logging.debug(f"Input text: {text}")
-        results = ke.extract_from_text(text)
+        results = ke.extract_from_text(text=text, show_prompt=show_prompt)
         write_extraction(results, output, output_format)
 
 
@@ -470,6 +473,7 @@ def pubmed_extract(model, pmid, template, output, output_format, get_pmc, **kwar
 @recurse_option
 @output_option_wb
 @output_format_options
+@show_prompt_option
 @click.option(
     "--limit",
     default=20,
@@ -481,7 +485,7 @@ def pubmed_extract(model, pmid, template, output, output_format, get_pmc, **kwar
     help="Attempt to parse PubMed Central full text(s) instead of abstract(s) alone.",
 )
 @click.argument("search")
-def pubmed_annotate(model, search, template, output, output_format, limit, get_pmc, **kwargs):
+def pubmed_annotate(model, search, template, output, output_format, limit, get_pmc, show_prompt, **kwargs):
     """Retrieve a collection of PubMed IDs for a search term; annotate them using a template.
 
     Example:
@@ -516,7 +520,7 @@ def pubmed_annotate(model, search, template, output, output_format, limit, get_p
         textlist = pmc.text(pmids[: pubmed_annotate_limit + 1])
     for text in textlist:
         logging.debug(f"Input text: {text}")
-        results = ke.extract_from_text(text)
+        results = ke.extract_from_text(text=text, show_prompt=show_prompt)
         write_extraction(results, output, output_format, ke)
 
 
@@ -526,9 +530,10 @@ def pubmed_annotate(model, search, template, output, output_format, limit, get_p
 @recurse_option
 @output_option_wb
 @output_format_options
+@show_prompt_option
 @click.option("--auto-prefix", default="AUTO", help="Prefix to use for auto-generated classes.")
 @click.argument("article")
-def wikipedia_extract(model, article, template, output, output_format, **kwargs):
+def wikipedia_extract(model, article, template, output, output_format, show_prompt, **kwargs):
     """Extract knowledge from a Wikipedia page."""
     if not model:
         model = DEFAULT_MODEL
@@ -551,7 +556,7 @@ def wikipedia_extract(model, article, template, output, output_format, **kwargs)
     text = client.text(article)
 
     logging.debug(f"Input text: {text}")
-    results = ke.extract_from_text(text)
+    results = ke.extract_from_text(text=text, show_prompt=show_prompt)
     write_extraction(results, output, output_format, ke)
 
 
@@ -561,6 +566,7 @@ def wikipedia_extract(model, article, template, output, output_format, **kwargs)
 @recurse_option
 @output_option_wb
 @output_format_options
+@show_prompt_option
 @click.option(
     "--keyword",
     "-k",
@@ -568,7 +574,7 @@ def wikipedia_extract(model, article, template, output, output_format, **kwargs)
     help="Keyword to search for (e.g. --keyword therapy). Also obtained from schema",
 )
 @click.argument("topic")
-def wikipedia_search(model, topic, keyword, template, output, output_format, **kwargs):
+def wikipedia_search(model, topic, keyword, template, output, output_format, show_prompt, **kwargs):
     """Extract knowledge from a Wikipedia page."""
     if not model:
         model = DEFAULT_MODEL
@@ -599,7 +605,7 @@ def wikipedia_search(model, topic, keyword, template, output, output_format, **k
             # TODO - expand this to fit context limits better
             # or add as cli option
             text = text[:4000]
-        results = ke.extract_from_text(text)
+        results = ke.extract_from_text(text=text, show_prompt=show_prompt)
         write_extraction(results, output, output_format)
         break
 
@@ -610,6 +616,7 @@ def wikipedia_search(model, topic, keyword, template, output, output_format, **k
 @recurse_option
 @output_option_wb
 @output_format_options
+@show_prompt_option
 @click.option(
     "--keyword",
     "-k",
@@ -617,7 +624,7 @@ def wikipedia_search(model, topic, keyword, template, output, output_format, **k
     help="Keyword to search for (e.g. --keyword therapy). Also obtained from schema",
 )
 @click.argument("term_tokens", nargs=-1)
-def search_and_extract(model, term_tokens, keyword, template, output, output_format, **kwargs):
+def search_and_extract(model, term_tokens, keyword, template, output, output_format, show_prompt, **kwargs):
     """Search for relevant literature and extract knowledge from it."""
     if not model:
         model = DEFAULT_MODEL
@@ -649,7 +656,7 @@ def search_and_extract(model, term_tokens, keyword, template, output, output_for
     logging.info(f"PMID={pmid}")
     text = pmc.text(pmid)
     logging.info(f"Input text: {text}")
-    results = ke.extract_from_text(text)
+    results = ke.extract_from_text(text=text, show_prompt=show_prompt)
     write_extraction(results, output, output_format)
 
 
@@ -659,8 +666,9 @@ def search_and_extract(model, term_tokens, keyword, template, output, output_for
 @recurse_option
 @output_option_wb
 @output_format_options
+@show_prompt_option
 @click.argument("url")
-def web_extract(model, template, url, output, output_format, **kwargs):
+def web_extract(model, template, url, output, output_format, show_prompt, **kwargs):
     """Extract knowledge from web page."""
     logging.info(f"Creating for {template}")
 
@@ -684,7 +692,7 @@ def web_extract(model, template, url, output, output_format, **kwargs):
     text = web_client.text(url)
 
     logging.debug(f"Input text: {text}")
-    results = ke.extract_from_text(text)
+    results = ke.extract_from_text(text=text, show_prompt=show_prompt)
     write_extraction(results, output, output_format)
 
 
@@ -699,8 +707,9 @@ def web_extract(model, template, url, output, output_format, **kwargs):
 )
 @click.option("--auto-prefix", default="AUTO", help="Prefix to use for auto-generated classes.")
 @model_option
+@show_prompt_option
 @click.argument("url")
-def recipe_extract(model, url, recipes_urls_file, dictionary, output, output_format, **kwargs):
+def recipe_extract(model, url, recipes_urls_file, dictionary, output, output_format, show_prompt, **kwargs):
     """Extract from recipe on the web."""
     try:
         from recipe_scrapers import scrape_me
@@ -747,7 +756,7 @@ def recipe_extract(model, url, recipes_urls_file, dictionary, output, output_for
     Instructions:\n{instructions}
     """
     logging.info(f"Input text: {text}")
-    results = ke.extract_from_text(text)
+    results = ke.extract_from_text(text=text, show_prompt=show_prompt)
     logging.debug(f"Results: {results}")
     results.extracted_object.url = url
     write_extraction(results, output, output_format, ke)
@@ -1445,8 +1454,9 @@ def eval(evaluator, num_tests, output, output_format, **kwargs):
 @recurse_option
 @output_option_wb
 @output_format_options
+@show_prompt_option
 @click.argument("object")
-def fill(model, template, object: str, examples, output, output_format, **kwargs):
+def fill(model, template, object: str, examples, output, output_format, show_prompt, **kwargs):
     """Fill in missing values."""
     logging.info(f"Creating for {template}")
 
@@ -1468,7 +1478,7 @@ def fill(model, template, object: str, examples, output, output_format, **kwargs
     logging.info(f"Loading {examples}")
     examples = yaml.safe_load(examples)
     logging.debug(f"Input object: {object}")
-    results = ke.generalize(object, examples)
+    results = ke.generalize(object, examples, show_prompt)
 
     output.write(yaml.dump(results.dict()))
 
@@ -1600,6 +1610,7 @@ def halo(model, input, context, terms, output, **kwargs):
 @model_option
 @output_option_wb
 @output_format_options
+@show_prompt_option
 @click.option(
     "-d",
     "--description",
@@ -1613,6 +1624,7 @@ def clinical_notes(
     sections,
     output,
     model,
+    show_prompt,
     output_format,
     **kwargs,
 ):
@@ -1637,7 +1649,7 @@ def clinical_notes(
 
     if model_source == "OpenAI":
         c = OpenAIClient(model=model_name)
-        results = c.complete(prompt)
+        results = c.complete(prompt, show_prompt)
 
     elif model_source == "GPT4All":
         c = set_up_gpt4all_model(modelname=model_name)

--- a/src/ontogpt/clients/openai_client.py
+++ b/src/ontogpt/clients/openai_client.py
@@ -24,14 +24,18 @@ class OpenAIClient:
     api_key: str = None
     interactive: bool = None
 
+    show_prompt: bool = False
+
     def __post_init__(self):
         if not self.api_key:
             self.api_key = get_apikey_value("openai")
         openai.api_key = self.api_key
 
-    def complete(self, prompt, max_tokens=3000, **kwargs) -> str:
+    def complete(self, prompt, show_prompt, max_tokens=3000, **kwargs) -> str:
         engine = self.model
         logger.info(f"Complete: engine={engine}, prompt[{len(prompt)}]={prompt[0:100]}...")
+        if show_prompt:
+            logger.info(f"Full prompt:\n{prompt}")
         cur = self.db_connection()
         res = cur.execute("SELECT payload FROM cache WHERE prompt=? AND engine=?", (prompt, engine))
         payload = res.fetchone()

--- a/src/ontogpt/clients/openai_client.py
+++ b/src/ontogpt/clients/openai_client.py
@@ -24,18 +24,16 @@ class OpenAIClient:
     api_key: str = None
     interactive: bool = None
 
-    show_prompt: bool = False
-
     def __post_init__(self):
         if not self.api_key:
             self.api_key = get_apikey_value("openai")
         openai.api_key = self.api_key
 
-    def complete(self, prompt, show_prompt, max_tokens=3000, **kwargs) -> str:
+    def complete(self, prompt, show_prompt: bool = False, max_tokens=3000, **kwargs) -> str:
         engine = self.model
         logger.info(f"Complete: engine={engine}, prompt[{len(prompt)}]={prompt[0:100]}...")
         if show_prompt:
-            logger.info(f"Full prompt:\n{prompt}")
+            logger.info(f" SENDING PROMPT:\n{prompt}")
         cur = self.db_connection()
         res = cur.execute("SELECT payload FROM cache WHERE prompt=? AND engine=?", (prompt, engine))
         payload = res.fetchone()

--- a/src/ontogpt/engines/gpt4all_engine.py
+++ b/src/ontogpt/engines/gpt4all_engine.py
@@ -62,7 +62,11 @@ class GPT4AllEngine(KnowledgeEngine):
             logging.info(f"Using template {self.template_class.name}")
 
     def extract_from_text(
-        self, text: str, cls: ClassDefinition = None, object: OBJECT = None
+        self,
+        text: str,
+        show_prompt: bool = False,
+        cls: ClassDefinition = None,
+        object: OBJECT = None,
     ) -> ExtractionResult:
         """
         Extract annotations from the given text.
@@ -78,6 +82,8 @@ class GPT4AllEngine(KnowledgeEngine):
             for chunk in chunks:
                 raw_text = self._raw_extract(chunk, cls, object=object)
                 logging.info(f"RAW TEXT: {raw_text}")
+                if show_prompt:
+                    logging.info(f" PROVIDED PROMPT:\n{self.last_prompt}")
                 next_object = self.parse_completion_payload(raw_text, cls, object=object)
                 if extracted_object is None:
                     extracted_object = next_object
@@ -93,6 +99,8 @@ class GPT4AllEngine(KnowledgeEngine):
         else:
             raw_text = self._raw_extract(text, cls, object=object)
             logging.info(f"RAW TEXT: {raw_text}")
+            if show_prompt:
+                logging.info(f" PROVIDED PROMPT:\n{self.last_prompt}")
             extracted_object = self.parse_completion_payload(raw_text, cls, object=object)
         return ExtractionResult(
             input_text=text,

--- a/src/ontogpt/templates/composite_disease.py
+++ b/src/ontogpt/templates/composite_disease.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+from datetime import datetime, date
+from enum import Enum
+from typing import List, Dict, Optional, Any, Union
+from pydantic import BaseModel as BaseModel, Field
+from linkml_runtime.linkml_model import Decimal
+import sys
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+
+metamodel_version = "None"
+version = "None"
+
+class WeakRefShimBaseModel(BaseModel):
+   __slots__ = '__weakref__'
+
+class ConfiguredBaseModel(WeakRefShimBaseModel,
+                validate_assignment = True,
+                validate_all = True,
+                underscore_attrs_are_private = True,
+                extra = 'forbid',
+                arbitrary_types_allowed = True,
+                use_enum_values = True):
+    pass
+
+
+class NCITDrugType(str, Enum):
+    
+    
+    dummy = "dummy"
+    
+
+class NCITTreatmentType(str, Enum):
+    
+    
+    dummy = "dummy"
+    
+
+class NCITTActivityType(str, Enum):
+    
+    
+    dummy = "dummy"
+    
+
+class MAXOActionType(str, Enum):
+    
+    
+    dummy = "dummy"
+    
+
+class MESHTherapeuticType(str, Enum):
+    
+    
+    dummy = "dummy"
+    
+
+class CHEBIDrugType(str, Enum):
+    
+    
+    dummy = "dummy"
+    
+
+class NullDataOptions(str, Enum):
+    
+    
+    UNSPECIFIED_METHOD_OF_ADMINISTRATION = "UNSPECIFIED_METHOD_OF_ADMINISTRATION"
+    
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    
+    NOT_MENTIONED = "NOT_MENTIONED"
+    
+    
+
+class CompositeDisease(ConfiguredBaseModel):
+    
+    main_disease: Optional[str] = Field(None, description="""the name of the disease that is treated.""")
+    drugs: Optional[List[str]] = Field(default_factory=list, description="""semicolon-separated list of named small molecule drugs""")
+    treatments: Optional[List[str]] = Field(default_factory=list, description="""semicolon-separated list of therapies and treatments are indicated for treating the disease.""")
+    contraindications: Optional[List[str]] = Field(default_factory=list, description="""semicolon-separated list of therapies and treatments that are contra-indicated for the disease, and should not be used, due to risk of adverse effects.""")
+    treatment_mechanisms: Optional[List[TreatmentMechanism]] = Field(default_factory=list, description="""semicolon-separated list of treatment to asterisk-separated mechanism associations""")
+    treatment_efficacies: Optional[List[TreatmentEfficacy]] = Field(default_factory=list, description="""semicolon-separated list of treatment to efficacy associations, e.g. Imatinib*effective""")
+    treatment_adverse_effects: Optional[List[TreatmentAdverseEffect]] = Field(default_factory=list, description="""semicolon-separated list of treatment to adverse effect associations, e.g. Imatinib*nausea""")
+    
+
+
+class ExtractionResult(ConfiguredBaseModel):
+    """
+    A result of extracting knowledge on text
+    """
+    input_id: Optional[str] = Field(None)
+    input_title: Optional[str] = Field(None)
+    input_text: Optional[str] = Field(None)
+    raw_completion_output: Optional[str] = Field(None)
+    prompt: Optional[str] = Field(None)
+    extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
+    named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
+    
+
+
+class NamedEntity(ConfiguredBaseModel):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Gene(NamedEntity):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Symptom(NamedEntity):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Disease(NamedEntity):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class AdverseEffect(NamedEntity):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Treatment(NamedEntity):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Mechanism(NamedEntity):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Drug(NamedEntity):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class CompoundExpression(ConfiguredBaseModel):
+    
+    None
+    
+
+
+class TreatmentMechanism(CompoundExpression):
+    
+    treatment: Optional[str] = Field(None)
+    mechanism: Optional[str] = Field(None)
+    
+
+
+class TreatmentAdverseEffect(CompoundExpression):
+    
+    treatment: Optional[str] = Field(None)
+    adverse_effects: Optional[List[str]] = Field(default_factory=list)
+    
+
+
+class TreatmentEfficacy(CompoundExpression):
+    
+    treatment: Optional[str] = Field(None)
+    efficacy: Optional[str] = Field(None)
+    
+
+
+class Triple(CompoundExpression):
+    """
+    Abstract parent for Relation Extraction tasks
+    """
+    subject: Optional[str] = Field(None)
+    predicate: Optional[str] = Field(None)
+    object: Optional[str] = Field(None)
+    qualifier: Optional[str] = Field(None, description="""A qualifier for the statements, e.g. \"NOT\" for negation""")
+    subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
+    object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
+    
+
+
+class TextWithTriples(ConfiguredBaseModel):
+    
+    publication: Optional[Publication] = Field(None)
+    triples: Optional[List[Triple]] = Field(default_factory=list)
+    
+
+
+class RelationshipType(NamedEntity):
+    
+    id: str = Field(..., description="""A unique identifier for the named entity""")
+    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
+    
+
+
+class Publication(ConfiguredBaseModel):
+    
+    id: Optional[str] = Field(None, description="""The publication identifier""")
+    title: Optional[str] = Field(None, description="""The title of the publication""")
+    abstract: Optional[str] = Field(None, description="""The abstract of the publication""")
+    combined_text: Optional[str] = Field(None)
+    full_text: Optional[str] = Field(None, description="""The full text of the publication""")
+    
+
+
+class AnnotatorResult(ConfiguredBaseModel):
+    
+    subject_text: Optional[str] = Field(None)
+    object_id: Optional[str] = Field(None)
+    object_text: Optional[str] = Field(None)
+    
+
+
+
+# Update forward refs
+# see https://pydantic-docs.helpmanual.io/usage/postponed_annotations/
+CompositeDisease.update_forward_refs()
+ExtractionResult.update_forward_refs()
+NamedEntity.update_forward_refs()
+Gene.update_forward_refs()
+Symptom.update_forward_refs()
+Disease.update_forward_refs()
+AdverseEffect.update_forward_refs()
+Treatment.update_forward_refs()
+Mechanism.update_forward_refs()
+Drug.update_forward_refs()
+CompoundExpression.update_forward_refs()
+TreatmentMechanism.update_forward_refs()
+TreatmentAdverseEffect.update_forward_refs()
+TreatmentEfficacy.update_forward_refs()
+Triple.update_forward_refs()
+TextWithTriples.update_forward_refs()
+RelationshipType.update_forward_refs()
+Publication.update_forward_refs()
+AnnotatorResult.update_forward_refs()
+


### PR DESCRIPTION
Extraction-based commands can be passed the `--show_prompts` flag.
If used with `-vvv`, *all* prompts will be output to the logger in their full form.
Without that verbose flag, no additional output will be provided.