### PR TITLE
Repairs for incorrect model specification

### DIFF
--- a/src/ontogpt/__init__.py
+++ b/src/ontogpt/__init__.py
@@ -12,6 +12,7 @@ with open(models_path, 'r') as models_file:
     MODELS = (safe_load(models_file))["models"]
 for model in MODELS:
     if "is_default" in model:
+        DEFAULT_MODEL_DETAILS = model
         DEFAULT_MODEL = model["alternative_names"][0]
         break
 

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -283,6 +283,7 @@ def extract(
         model = DEFAULT_MODEL
     selectmodel = get_model_by_name(model)
     model_source = selectmodel["provider"]
+    model_name = selectmodel["alternative_names"][0]
 
     if not inputfile or inputfile == "-":
         text = sys.stdin.read()
@@ -299,14 +300,13 @@ def extract(
         raise FileNotFoundError(f"Cannot find input file {inputfile}")
 
     if model_source == "OpenAI":
-        ke = SPIRESEngine(template, **kwargs)
+        ke = SPIRESEngine(template=template, model=model_name, **kwargs)
         if settings.cache_db:
             ke.client.cache_db_path = settings.cache_db
         if settings.skip_annotators:
             ke.client.skip_annotators = settings.skip_annotators
 
     elif model_source == "GPT4All":
-        model_name = selectmodel["alternative_names"][0]
         ke = GPT4AllEngine(template=template, model=model_name, **kwargs)
 
     elif model_source == "HuggingFace Hub":

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -22,7 +22,7 @@ from sssom.parsers import parse_sssom_table, to_mapping_set_document
 from sssom.util import to_mapping_set_dataframe
 
 import ontogpt.ontex.extractor as extractor
-from ontogpt import DEFAULT_MODEL, MODELS, __version__
+from ontogpt import DEFAULT_MODEL, DEFAULT_MODEL_DETAILS, MODELS, __version__
 from ontogpt.clients import OpenAIClient
 from ontogpt.clients.pubmed_client import PubmedClient
 from ontogpt.clients.soup_client import SoupClient
@@ -127,12 +127,16 @@ def get_model_by_name(modelname: str):
         if modelname in knownmodel["alternative_names"] or modelname == knownmodel["name"]:
             selectmodel = knownmodel
             found = True
+            logging.info(
+                f"Found model: {selectmodel['name']}, provided by {selectmodel['provider']}."
+            )
             break
     if not found:
         logging.warning(
             f"""Model name not recognized or not supported yet. Using default, {DEFAULT_MODEL}.
             See all models with `ontogpt list-models`"""
         )
+        selectmodel = DEFAULT_MODEL_DETAILS
 
     return selectmodel
 
@@ -485,7 +489,9 @@ def pubmed_extract(model, pmid, template, output, output_format, get_pmc, show_p
     help="Attempt to parse PubMed Central full text(s) instead of abstract(s) alone.",
 )
 @click.argument("search")
-def pubmed_annotate(model, search, template, output, output_format, limit, get_pmc, show_prompt, **kwargs):
+def pubmed_annotate(
+    model, search, template, output, output_format, limit, get_pmc, show_prompt, **kwargs
+):
     """Retrieve a collection of PubMed IDs for a search term; annotate them using a template.
 
     Example:
@@ -624,7 +630,9 @@ def wikipedia_search(model, topic, keyword, template, output, output_format, sho
     help="Keyword to search for (e.g. --keyword therapy). Also obtained from schema",
 )
 @click.argument("term_tokens", nargs=-1)
-def search_and_extract(model, term_tokens, keyword, template, output, output_format, show_prompt, **kwargs):
+def search_and_extract(
+    model, term_tokens, keyword, template, output, output_format, show_prompt, **kwargs
+):
     """Search for relevant literature and extract knowledge from it."""
     if not model:
         model = DEFAULT_MODEL
@@ -709,7 +717,9 @@ def web_extract(model, template, url, output, output_format, show_prompt, **kwar
 @model_option
 @show_prompt_option
 @click.argument("url")
-def recipe_extract(model, url, recipes_urls_file, dictionary, output, output_format, show_prompt, **kwargs):
+def recipe_extract(
+    model, url, recipes_urls_file, dictionary, output, output_format, show_prompt, **kwargs
+):
     """Extract from recipe on the web."""
     try:
         from recipe_scrapers import scrape_me

--- a/src/ontogpt/models.yaml
+++ b/src/ontogpt/models.yaml
@@ -33,17 +33,6 @@ models:
       diskspace: "N/A"
       memory: "N/A"
 
-  - name: MODEL_GPT_3_5_TURBO_16K
-    alternative_names:
-      - "gpt-3.5-turbo-16k"
-      - "openai-gpt-3.5-turbo-16k"
-    provider: OpenAI
-    creators:
-      - OpenAI
-    requirements:
-      diskspace: "N/A"
-      memory: "N/A"
-
   - name: MODEL_GPT_4
     alternative_names:
       - "gpt-4"


### PR DESCRIPTION
Fixes for:
* #191 
* Case when provided model name wasn't matching any known model - this should revert to the default model but was raising an error.
* A duplicate model name in the `models.yaml` - didn't cause error but may cause confusion.