### PR TITLE
Fixed bug where named arguments did not match up in recurse function.

### DIFF
--- a/src/ontogpt/clients/openai_client.py
+++ b/src/ontogpt/clients/openai_client.py
@@ -29,7 +29,7 @@ class OpenAIClient:
             self.api_key = get_apikey_value("openai")
         openai.api_key = self.api_key
 
-    def complete(self, prompt, show_prompt: bool = False, max_tokens=3000, **kwargs) -> str:
+    def complete(self, prompt, max_tokens=3000, show_prompt: bool = False, **kwargs) -> str:
         engine = self.model
         logger.info(f"Complete: engine={engine}, prompt[{len(prompt)}]={prompt[0:100]}...")
         if show_prompt:

--- a/src/ontogpt/engines/gpt4all_engine.py
+++ b/src/ontogpt/engines/gpt4all_engine.py
@@ -80,7 +80,7 @@ class GPT4AllEngine(KnowledgeEngine):
             chunks = chunk_text(text, self.sentences_per_window)
             extracted_object = None
             for chunk in chunks:
-                raw_text = self._raw_extract(chunk, cls, object=object)
+                raw_text = self._raw_extract(chunk, cls=cls, object=object)
                 logging.info(f"RAW TEXT: {raw_text}")
                 if show_prompt:
                     logging.info(f" PROVIDED PROMPT:\n{self.last_prompt}")
@@ -97,11 +97,11 @@ class GPT4AllEngine(KnowledgeEngine):
                             else:
                                 extracted_object[k] = v
         else:
-            raw_text = self._raw_extract(text, cls, object=object)
+            raw_text = self._raw_extract(text=text, cls=cls, object=object)
             logging.info(f"RAW TEXT: {raw_text}")
             if show_prompt:
                 logging.info(f" PROVIDED PROMPT:\n{self.last_prompt}")
-            extracted_object = self.parse_completion_payload(raw_text, cls, object=object)
+            extracted_object = self.parse_completion_payload(raw_text, cls=cls, object=object)
         return ExtractionResult(
             input_text=text,
             raw_completion_output=raw_text,
@@ -111,7 +111,7 @@ class GPT4AllEngine(KnowledgeEngine):
         )
 
     def _extract_from_text_to_dict(self, text: str, cls: ClassDefinition = None) -> RESPONSE_DICT:
-        raw_text = self._raw_extract(text, cls)
+        raw_text = self._raw_extract(text=text, cls=cls)
         return self._parse_response_to_dict(raw_text, cls)
 
     def iteratively_generate_and_extract(

--- a/src/ontogpt/engines/spires_engine.py
+++ b/src/ontogpt/engines/spires_engine.py
@@ -59,9 +59,9 @@ class SPIRESEngine(KnowledgeEngine):
     def extract_from_text(
         self,
         text: str,
-        show_prompt: bool = False,
         cls: ClassDefinition = None,
         object: OBJECT = None,
+        show_prompt: bool = False,
     ) -> ExtractionResult:
         """
         Extract annotations from the given text.
@@ -90,7 +90,7 @@ class SPIRESEngine(KnowledgeEngine):
                             else:
                                 extracted_object[k] = v
         else:
-            raw_text = self._raw_extract(text=text, cls=cls, show_prompt=show_prompt, object=object)
+            raw_text = self._raw_extract(text=text, cls=cls, object=object, show_prompt=show_prompt)
             logging.info(f"RAW TEXT: {raw_text}")
             extracted_object = self.parse_completion_payload(raw_text, cls, object=object)
         return ExtractionResult(
@@ -102,11 +102,11 @@ class SPIRESEngine(KnowledgeEngine):
         )
 
     def _extract_from_text_to_dict(self, text: str, cls: ClassDefinition = None) -> RESPONSE_DICT:
-        raw_text = self._raw_extract(text, cls=cls)
+        raw_text = self._raw_extract(text=text, cls=cls)
         return self._parse_response_to_dict(raw_text, cls)
 
     def generate_and_extract(
-        self, entity: str, show_prompt: bool = False, prompt_template: str = None, **kwargs
+        self, entity: str, prompt_template: str = None, show_prompt: bool = False, **kwargs
     ) -> ExtractionResult:
         """
         Generate a description using GPT and then extract from it using SPIRES.
@@ -166,7 +166,7 @@ class SPIRESEngine(KnowledgeEngine):
             else:
                 curie = None
             result = self.generate_and_extract(
-                next_entity, show_prompt=show_prompt, prompt_template=prompt_template, **kwargs
+                next_entity, prompt_template=prompt_template, show_prompt=show_prompt, **kwargs
             )
             if curie:
                 if result.extracted_object:

--- a/src/ontogpt/engines/spires_engine.py
+++ b/src/ontogpt/engines/spires_engine.py
@@ -365,9 +365,9 @@ class SPIRESEngine(KnowledgeEngine):
         :param text:
         :return:
         """
-        prompt = self.get_completion_prompt(cls, text, object=object)
+        prompt = self.get_completion_prompt(cls=cls, text=text, object=object)
         self.last_prompt = prompt
-        payload = self.client.complete(prompt, show_prompt)
+        payload = self.client.complete(prompt=prompt, show_prompt=show_prompt)
         return payload
 
     def get_completion_prompt(


### PR DESCRIPTION
Fixes #197

General guidelines:

- name arguments to calls unless order is absolutely predictable
- when adding new arguments to an existing function call, these go at the end by default
