### PR TITLE
Fix for #215

### DIFF
--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -105,7 +105,7 @@ def write_extraction(
             exporter = HTMLExporter(output=output)
             exporter.export(results, output)
         elif output_format == "yaml":
-            output.write("---\n")
+            output.write("---\n")  # type: ignore
             output.write(dump_minimal_yaml(results))  # type: ignore
         elif output_format == "turtle":
             exporter = RDFExporter()
@@ -120,7 +120,7 @@ def write_extraction(
                 for line in output_parser(obj=results, file=output):
                     secondoutput.write(line)
         else:
-            output.write("---\n")
+            output.write("---\n")  # type: ignore
             output.write(dump_minimal_yaml(results))  # type: ignore
 
 

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -339,7 +339,6 @@ def extract(
     write_extraction(results, output, output_format, ke)
 
 
-# TODO: combine this command with pubmed_annotate - they are converging
 @main.command()
 @template_option
 @model_option
@@ -436,7 +435,7 @@ def iteratively_generate_extract(
     ):
         write_extraction(results, output, output_format)
 
-
+# TODO: combine this command with pubmed_annotate - they are converging
 @main.command()
 @template_option
 @model_option

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -437,6 +437,7 @@ def iteratively_generate_extract(
     ):
         write_extraction(results, output, output_format)
 
+
 # TODO: combine this command with pubmed_annotate - they are converging
 @main.command()
 @template_option

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -105,6 +105,7 @@ def write_extraction(
             exporter = HTMLExporter(output=output)
             exporter.export(results, output)
         elif output_format == "yaml":
+            output.write("---\n")
             output.write(dump_minimal_yaml(results))  # type: ignore
         elif output_format == "turtle":
             exporter = RDFExporter()
@@ -119,6 +120,7 @@ def write_extraction(
                 for line in output_parser(obj=results, file=output):
                     secondoutput.write(line)
         else:
+            output.write("---\n")
             output.write(dump_minimal_yaml(results))  # type: ignore
 
 

--- a/src/ontogpt/engines/spires_engine.py
+++ b/src/ontogpt/engines/spires_engine.py
@@ -79,7 +79,7 @@ class SPIRESEngine(KnowledgeEngine):
                 logging.info(f"RAW TEXT: {raw_text}")
                 next_object = self.parse_completion_payload(
                     raw_text, cls, object=object  # type: ignore
-                )  
+                )
                 if extracted_object is None:
                     extracted_object = next_object
                 else:
@@ -96,7 +96,7 @@ class SPIRESEngine(KnowledgeEngine):
             logging.info(f"RAW TEXT: {raw_text}")
             extracted_object = self.parse_completion_payload(
                 raw_text, cls, object=object  # type: ignore
-            )  
+            )
         return ExtractionResult(
             input_text=text,
             raw_completion_output=raw_text,
@@ -516,13 +516,13 @@ class SPIRESEngine(KnowledgeEngine):
                 logging.debug(f"  RECURSING ON SLOT: {slot.name}, range={slot_range.name}")
                 vals = [
                     self._extract_from_text_to_dict(v, slot_range) for v in vals  # type: ignore
-                ]  
+                ]
             else:
                 for sep in [" - ", ":", "/", "*", "-"]:
                     if all([sep in v for v in vals]):
                         vals = [
                             dict(zip(slots_of_range, v.split(sep, 1))) for v in vals  # type: ignore
-                        ]  
+                        ]
                         for v in vals:
                             for k in v.keys():  # type: ignore
                                 v[k] = v[k].strip()  # type: ignore

--- a/src/ontogpt/evaluation/hpoa/eval_hpoa.py
+++ b/src/ontogpt/evaluation/hpoa/eval_hpoa.py
@@ -21,7 +21,7 @@ from ontogpt.templates.mendelian_disease import MendelianDisease
 DATABASE_DIR = Path(__file__).parent / "database"
 TEST_CASES_DIR = Path("tests").joinpath("input")
 TEST_HPOA_FILE = "test_sample.hpoa.tsv"
-NUM_TESTS = 3 # Note: each test requires input text; see provided test cases
+NUM_TESTS = 3  # Note: each test requires input text; see provided test cases
 
 DISEASE_ID = str
 TERM = str
@@ -182,7 +182,7 @@ class EvalHPOA(SPIRESEvaluationEngine):
         eos.training = []
         eos.predictions = []
         shuffle(eos.test)
-        for test_case in eos.test[0:num_tests-1]:
+        for test_case in eos.test[0 : num_tests - 1]:
             # text = self.disease_text(test_case.id)
             if len(test_case.publications) != 1:
                 raise ValueError(f"Expected 1 publication, got {len(test_case.publications)}")

--- a/src/ontogpt/io/yaml_wrapper.py
+++ b/src/ontogpt/io/yaml_wrapper.py
@@ -5,7 +5,6 @@ from typing import Any, Optional, TextIO
 
 import pydantic
 from ruamel.yaml import YAML, RoundTripRepresenter
-from ruamel.yaml.comments import CommentedMap
 
 # import yaml
 # from yaml import SafeDumper

--- a/src/ontogpt/io/yaml_wrapper.py
+++ b/src/ontogpt/io/yaml_wrapper.py
@@ -19,7 +19,7 @@ def eliminate_empty(obj: Any, preserve=False) -> Any:
     elif isinstance(obj, dict):
         return {k: eliminate_empty(v, preserve) for k, v in obj.items() if v or preserve}
     elif isinstance(obj, pydantic.BaseModel):
-        return eliminate_empty(obj.dict(), preserve)
+        return eliminate_empty(obj.model_dump(), preserve)
     elif isinstance(obj, tuple):
         return [eliminate_empty(x, preserve) for x in obj]
     elif isinstance(obj, str):

--- a/src/ontogpt/io/yaml_wrapper.py
+++ b/src/ontogpt/io/yaml_wrapper.py
@@ -43,17 +43,13 @@ def repr_str(dumper: RoundTripRepresenter, data: str):
 def dump_minimal_yaml(obj: Any, minimize=True, file: Optional[TextIO] = None) -> str:
     """Dump a YAML string, but eliminating Nones and empty lists and dicts."""
     yaml = YAML()
-    separator = YAML().load("")
     yaml.representer.add_representer(str, repr_str)
     yaml.default_flow_style = False
-    yaml.default_style=None
     yaml.indent(sequence=4, offset=2)
-    # A bit of a hack here to ensure all yaml output has a separator, even
-    # if it's a single document
     if not file:
         file = io.StringIO()
-        yaml.dump_all(documents=[separator, eliminate_empty(obj, not minimize)], stream=file)
+        yaml.dump(eliminate_empty(obj, not minimize), file)
         return file.getvalue()
     else:
-        yaml.dump_all(documents=[separator, eliminate_empty(obj, not minimize)], stream=file)
+        yaml.dump(eliminate_empty(obj, not minimize), file)
         return ""

--- a/src/ontogpt/io/yaml_wrapper.py
+++ b/src/ontogpt/io/yaml_wrapper.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, TextIO
 
 import pydantic
 from ruamel.yaml import YAML, RoundTripRepresenter
+from ruamel.yaml.comments import CommentedMap
 
 # import yaml
 # from yaml import SafeDumper
@@ -42,13 +43,17 @@ def repr_str(dumper: RoundTripRepresenter, data: str):
 def dump_minimal_yaml(obj: Any, minimize=True, file: Optional[TextIO] = None) -> str:
     """Dump a YAML string, but eliminating Nones and empty lists and dicts."""
     yaml = YAML()
+    separator = YAML().load("")
     yaml.representer.add_representer(str, repr_str)
     yaml.default_flow_style = False
+    yaml.default_style=None
     yaml.indent(sequence=4, offset=2)
+    # A bit of a hack here to ensure all yaml output has a separator, even
+    # if it's a single document
     if not file:
         file = io.StringIO()
-        yaml.dump(eliminate_empty(obj, not minimize), file)
+        yaml.dump_all(documents=[separator, eliminate_empty(obj, not minimize)], stream=file)
         return file.getvalue()
     else:
-        yaml.dump(eliminate_empty(obj, not minimize), file)
+        yaml.dump_all(documents=[separator, eliminate_empty(obj, not minimize)], stream=file)
         return ""


### PR DESCRIPTION
Ensure YAML output contains separators so multiple documents may be loaded.
These need to go on outputs even if they're only a single doc (note that ruamel.yaml has a method called dump_all, but this only includes separators for multiple doc outputs).