### PR TITLE
Reduce redundancy in named entity list in evals

### DIFF
--- a/src/ontogpt/evaluation/ctd/eval_ctd.py
+++ b/src/ontogpt/evaluation/ctd/eval_ctd.py
@@ -204,13 +204,14 @@ class EvalCTD(SPIRESEvaluationEngine):
             predictions=[],
         )
         n = 1
+        named_entities: List[str] = []
         for doc in eos.test:
             logger.info(f"Iteration {n} of {num_test}")
             n += 1
             logger.info(doc)
             text = f"Title: {doc.publication.title} Abstract: {doc.publication.abstract}"
             predicted_obj = None
-            named_entities: List[str] = []
+            named_entities.clear()
             for chunked_text in chunk_text(text):
                 extraction = ke.extract_from_text(chunked_text)
                 if extraction.extracted_object is not None:
@@ -227,7 +228,9 @@ class EvalCTD(SPIRESEvaluationEngine):
                             f"{len(predicted_obj.triples)} total triples, after concatenation"
                         )
                         logger.debug(f"concatenated triples: {predicted_obj.triples}")
-                named_entities.extend(extraction.named_entities)
+                for entity in extraction.named_entities:
+                    if entity not in named_entities:
+                        named_entities.append(entity)
 
             def included(t: ChemicalToDiseaseRelationship):
                 if not [var for var in (t.subject, t.object, t.predicate) if var is None]:

--- a/src/ontogpt/evaluation/ctd/eval_ctd.py
+++ b/src/ontogpt/evaluation/ctd/eval_ctd.py
@@ -249,8 +249,10 @@ class EvalCTD(SPIRESEvaluationEngine):
             logger.info(
                 f"{len(predicted_obj.triples)} filtered triples (CID only, between MESH only)"
             )
-            pred = PredictionRE(predicted_object=predicted_obj, test_object=doc)
-            pred.named_entities = named_entities
+            pred = PredictionRE(
+                predicted_object=predicted_obj, test_object=doc, named_entities=named_entities
+            )
+            named_entities.clear()
             logger.info("PRED")
             logger.info(yaml.dump(data=pred.model_dump()))
             logger.info("Calc scores")

--- a/src/ontogpt/evaluation/ctd/eval_ctd.py
+++ b/src/ontogpt/evaluation/ctd/eval_ctd.py
@@ -251,7 +251,7 @@ class EvalCTD(SPIRESEvaluationEngine):
             unique_predicted_triples = [
                 t
                 for t in predicted_obj.triples
-                if t not in duplicate_triples and not duplicate_triples.append(t)
+                if t not in duplicate_triples and not duplicate_triples.append(t)  # type: ignore
             ]
             predicted_obj.triples = unique_predicted_triples
             logger.info(

--- a/src/ontogpt/evaluation/ctd/eval_ctd.py
+++ b/src/ontogpt/evaluation/ctd/eval_ctd.py
@@ -204,14 +204,14 @@ class EvalCTD(SPIRESEvaluationEngine):
             predictions=[],
         )
         n = 1
-        named_entities: List[str] = []
         for doc in eos.test:
             logger.info(f"Iteration {n} of {num_test}")
             n += 1
             logger.info(doc)
             text = f"Title: {doc.publication.title} Abstract: {doc.publication.abstract}"
             predicted_obj = None
-            named_entities.clear()
+            named_entities: List[str] = [] # This stores the NEs for the whole document
+            ke.named_entities = [] # This stores the NEs the extractor knows about
             for chunked_text in chunk_text(text):
                 extraction = ke.extract_from_text(chunked_text)
                 if extraction.extracted_object is not None:
@@ -228,9 +228,10 @@ class EvalCTD(SPIRESEvaluationEngine):
                             f"{len(predicted_obj.triples)} total triples, after concatenation"
                         )
                         logger.debug(f"concatenated triples: {predicted_obj.triples}")
-                for entity in extraction.named_entities:
-                    if entity not in named_entities:
-                        named_entities.append(entity)
+                if extraction.named_entities is not None:
+                    for entity in extraction.named_entities:
+                        if entity not in named_entities:
+                            named_entities.append(entity)
 
             def included(t: ChemicalToDiseaseRelationship):
                 if not [var for var in (t.subject, t.object, t.predicate) if var is None]:

--- a/src/ontogpt/evaluation/ctd/eval_ctd.py
+++ b/src/ontogpt/evaluation/ctd/eval_ctd.py
@@ -210,8 +210,8 @@ class EvalCTD(SPIRESEvaluationEngine):
             logger.info(doc)
             text = f"Title: {doc.publication.title} Abstract: {doc.publication.abstract}"
             predicted_obj = None
-            named_entities: List[str] = [] # This stores the NEs for the whole document
-            ke.named_entities = [] # This stores the NEs the extractor knows about
+            named_entities: List[str] = []  # This stores the NEs for the whole document
+            ke.named_entities = []  # This stores the NEs the extractor knows about
             for chunked_text in chunk_text(text):
                 extraction = ke.extract_from_text(chunked_text)
                 if extraction.extracted_object is not None:
@@ -247,6 +247,13 @@ class EvalCTD(SPIRESEvaluationEngine):
                     return t
 
             predicted_obj.triples = [t for t in predicted_obj.triples if included(t)]
+            duplicate_triples = []
+            unique_predicted_triples = [
+                t
+                for t in predicted_obj.triples
+                if t not in duplicate_triples and not duplicate_triples.append(t)
+            ]
+            predicted_obj.triples = unique_predicted_triples
             logger.info(
                 f"{len(predicted_obj.triples)} filtered triples (CID only, between MESH only)"
             )


### PR DESCRIPTION
This is specific to the CTD eval for now, but hoping to avoid the same issue in other evals.
Fix #235.
Also include only unique predicted triples in output - many of these were fully redundant in the final object, though the extras were not included in score calculations since those are based on sets.