### PR TITLE
Add `model` parameter to evaluation engine

### DIFF
--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -1450,6 +1450,7 @@ def eval_enrichment(genes, input_file, number_to_drop, annotations_path, model, 
 
 @main.command()
 @recurse_option
+@model_option
 @output_option_txt
 @click.option(
     "--num-tests",
@@ -1466,12 +1467,18 @@ def eval_enrichment(genes, input_file, number_to_drop, annotations_path, model, 
             " Otherwise the full input text is passed.",
 )
 @click.argument("evaluator")
-def eval(evaluator, num_tests, output, chunking, **kwargs):
+def eval(evaluator, num_tests, output, chunking, model, **kwargs):
     """Evaluate an extractor."""
     logging.info(f"Creating for {evaluator}")
+
+    if model:
+        selectmodel = get_model_by_name(model)
+        modelname = selectmodel["alternative_names"][0]
+
     evaluator = create_evaluator(evaluator)
     evaluator.num_tests = num_tests
     evaluator.chunking = chunking
+    evaluator.model = modelname
     eos = evaluator.eval()
     output.write(dump_minimal_yaml(eos, minimize=False))
 

--- a/src/ontogpt/evaluation/ctd/eval_ctd.py
+++ b/src/ontogpt/evaluation/ctd/eval_ctd.py
@@ -136,7 +136,8 @@ class EvalCTD(SPIRESEvaluationEngine):
     object_prefix = "MESH"
 
     def __post_init__(self):
-        self.extractor = SPIRESEngine("ctd.ChemicalToDiseaseDocument")
+        self.extractor = SPIRESEngine(template="ctd.ChemicalToDiseaseDocument",
+                                      model=self.model)
         # synonyms are derived entirely from training set
         self.extractor.load_dictionary(DATABASE_DIR / "synonyms.yaml")
 

--- a/src/ontogpt/evaluation/evaluation_engine.py
+++ b/src/ontogpt/evaluation/evaluation_engine.py
@@ -16,6 +16,7 @@ from typing import List, Optional, Set
 from oaklib import BasicOntologyInterface
 from pydantic import BaseModel
 
+from ontogpt import DEFAULT_MODEL
 from ontogpt.engines.spires_engine import SPIRESEngine
 
 
@@ -99,3 +100,7 @@ class SPIRESEvaluationEngine(EvaluationEngine):
     chunking: bool = False
     """Whether to pre-process input texts by chunking. If True, each chunk gets its own
     prompt. Otherwise, pass the full text with each prompt."""
+
+    model: str = DEFAULT_MODEL
+    """Name of the model to use in evaluation. Defaults to the default model defined
+    in models.yaml, generally gpt-3.5-turbo."""


### PR DESCRIPTION
The evaluation engine now accepts a model name through the `eval` command.