### PR TITLE
Added links to a tutorial and a presentation about OntoGPT and CurateGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ OpenAI's functions have been evaluated on test data. Please see the full documen
 - Presentation: "Staying grounded: assembling structured biological knowledge with help from large language models" - presented by Harry Caufield as part of the AgBioData Consortium webinar series (September 2023) 
   - [Slides](https://docs.google.com/presentation/d/1rMQVWaMju-ucYFif5nx4Xv3bNX2SVI_w89iBIT1bkV4/edit?usp=sharing)
   - [Video](https://www.youtube.com/watch?v=z38lI6WyBsY)
-- Presentation: "Transforming unstructured biomedical texts with large language models" - presented by Harry Caufield at part of the BOSC track at ISMB/ECCB 2023 (July 2023) 
+- Presentation: "Transforming unstructured biomedical texts with large language models" - presented by Harry Caufield as part of the BOSC track at ISMB/ECCB 2023 (July 2023) 
   - [Slides](https://docs.google.com/presentation/d/1LsOTKi-rXYczL9vUTHB1NDkaEqdA9u3ZFC5ANa0x1VU/edit?usp=sharing)
   - [Video](https://www.youtube.com/watch?v=a34Yjz5xPp4)
 - Presentation: "OntoGPT: A framework for working with ontologies and large language models" - talk by Chris Mungall at Joint Food Ontology Workgroup (May 2023)

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ NOTE: We do not recommend hosting this webapp publicly without authentication.
 OpenAI's functions have been evaluated on test data. Please see the full documentation for details on these evaluations and how to reproduce them.
 
 ## Tutorials and Presentations
-- Tutorial: "Enhancing curation workflows with CurateGPT" - presented by Chris Mungall as part of the [OBO Academy](https://oboacademy.github.io/obook/courses/monarch-obo-training/) series (November 2023) 
-  - [Slides](https://docs.google.com/presentation/d/1IrpA8gEDhQupjGGb9MBMg5siTJjeL2fm1lltJ64vkUo/edit)
-  - [Video](https://www.youtube.com/watch?v=p6j3WwzIv40)
+- Presentation: "Enhancing curation workflows with CurateGPT" - presented by Harry Caufield at part of the BOSC track at ISMB/ECCB 2023 (July 2023) 
+  - [Slides](https://docs.google.com/presentation/d/1LsOTKi-rXYczL9vUTHB1NDkaEqdA9u3ZFC5ANa0x1VU/edit?usp=sharing)
+  - [Video](https://www.youtube.com/watch?v=a34Yjz5xPp4)
 - Presentation: "OntoGPT: A framework for working with ontologies and large language models" - talk by Chris Mungall at Joint Food Ontology Workgroup (May 2023)
   - [Slides](https://docs.google.com/presentation/d/1CosJJe8SqwyALyx85GWkw9eOT43B4HwDlAY2CmkmJgU/edit)
   - [Video](https://www.youtube.com/watch?v=rt3wobA9hEs&t=1955s)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ NOTE: We do not recommend hosting this webapp publicly without authentication.
 OpenAI's functions have been evaluated on test data. Please see the full documentation for details on these evaluations and how to reproduce them.
 
 ## Tutorials and Presentations
-- Presentation: "Enhancing curation workflows with CurateGPT" - presented by Harry Caufield at part of the BOSC track at ISMB/ECCB 2023 (July 2023) 
+- Presentation: "Staying grounded: assembling structured biological knowledge with help from large language models" - presented by Harry Caufield at part of the AgBioData Consortium webinar series (September 2023) 
+  - [Slides](https://docs.google.com/presentation/d/1rMQVWaMju-ucYFif5nx4Xv3bNX2SVI_w89iBIT1bkV4/edit?usp=sharing)
+  - [Video](https://www.youtube.com/watch?v=z38lI6WyBsY)
+- Presentation: "Transforming unstructured biomedical texts with large language models" - presented by Harry Caufield at part of the BOSC track at ISMB/ECCB 2023 (July 2023) 
   - [Slides](https://docs.google.com/presentation/d/1LsOTKi-rXYczL9vUTHB1NDkaEqdA9u3ZFC5ANa0x1VU/edit?usp=sharing)
   - [Video](https://www.youtube.com/watch?v=a34Yjz5xPp4)
 - Presentation: "OntoGPT: A framework for working with ontologies and large language models" - talk by Chris Mungall at Joint Food Ontology Workgroup (May 2023)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ NOTE: We do not recommend hosting this webapp publicly without authentication.
 OpenAI's functions have been evaluated on test data. Please see the full documentation for details on these evaluations and how to reproduce them.
 
 ## Tutorials and Presentations
-- Presentation: "Staying grounded: assembling structured biological knowledge with help from large language models" - presented by Harry Caufield at part of the AgBioData Consortium webinar series (September 2023) 
+- Presentation: "Staying grounded: assembling structured biological knowledge with help from large language models" - presented by Harry Caufield as part of the AgBioData Consortium webinar series (September 2023) 
   - [Slides](https://docs.google.com/presentation/d/1rMQVWaMju-ucYFif5nx4Xv3bNX2SVI_w89iBIT1bkV4/edit?usp=sharing)
   - [Video](https://www.youtube.com/watch?v=z38lI6WyBsY)
 - Presentation: "Transforming unstructured biomedical texts with large language models" - presented by Harry Caufield at part of the BOSC track at ISMB/ECCB 2023 (July 2023) 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ NOTE: We do not recommend hosting this webapp publicly without authentication.
 
 OpenAI's functions have been evaluated on test data. Please see the full documentation for details on these evaluations and how to reproduce them.
 
+## Tutorials and Presentations
+- Tutorial: "Enhancing curation workflows with CurateGPT" - presented by Chris Mungall as part of the [OBO Academy](https://oboacademy.github.io/obook/courses/monarch-obo-training/) series (November 2023) 
+  - [Slides](https://docs.google.com/presentation/d/1IrpA8gEDhQupjGGb9MBMg5siTJjeL2fm1lltJ64vkUo/edit)
+  - [Video](https://www.youtube.com/watch?v=p6j3WwzIv40)
+- Presentation: "OntoGPT: A framework for working with ontologies and large language models" - talk by Chris Mungall at Joint Food Ontology Workgroup (May 2023)
+  - [Slides](https://docs.google.com/presentation/d/1CosJJe8SqwyALyx85GWkw9eOT43B4HwDlAY2CmkmJgU/edit)
+  - [Video](https://www.youtube.com/watch?v=rt3wobA9hEs&t=1955s)
+
 ## Citation
 
 The information extraction approach used in OntoGPT, SPIRES, is described further in: Caufield JH, Hegde H, Emonet V, Harris NL, Joachimiak MP, Matentzoglu N, et al. Structured prompt interrogation and recursive extraction of semantics (SPIRES): A method for populating knowledge bases using zero-shot learning. arXiv publication: <http://arxiv.org/abs/2304.02711>


### PR DESCRIPTION
fix #256

@cmungall the CurateGPT OBO Academy video was public on YouTube; I assume it's also ok to share the link to the slides?