### PR TITLE
Enable running extractions on all files in a directory

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -36,6 +36,10 @@ The following options are available for most functions unless stated otherwise.
 
 Use the option `--inputfile` to specify a path to a file containing input text.
 
+For the `extract` command, this may be a single file or a directory of files.
+
+In the latter case, all .txt files will be assumed to be input, and the path will *not* be parsed recursively.
+
 ### template
 
 Use the option `--template` to specify a template to use. This is a required parameter.

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -353,7 +353,7 @@ def extract(
     for input_entry in inputlist:
         if len(inputlist) > 1:
             i = i + 1
-            logging.info(f"Now reading file {i} of {len(inputlist)}")
+            logging.info(f"Now extracting from file {i} of {len(inputlist)}")
         results = ke.extract_from_text(
             text=input_entry, cls=target_class_def, show_prompt=show_prompt
         )

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -1464,7 +1464,7 @@ def eval_enrichment(genes, input_file, number_to_drop, annotations_path, model, 
     default=False,
     show_default=True,
     help="If set, chunk input text, then prepare a separate prompt for each chunk."
-            " Otherwise the full input text is passed.",
+    " Otherwise the full input text is passed.",
 )
 @click.argument("evaluator")
 def eval(evaluator, num_tests, output, chunking, model, **kwargs):
@@ -1477,10 +1477,9 @@ def eval(evaluator, num_tests, output, chunking, model, **kwargs):
     else:
         modelname = DEFAULT_MODEL
 
-    evaluator = create_evaluator(name=evaluator,
-                                 num_tests=num_tests,
-                                 chunking=chunking,
-                                 model=modelname)
+    evaluator = create_evaluator(
+        name=evaluator, num_tests=num_tests, chunking=chunking, model=modelname
+    )
     eos = evaluator.eval()
     output.write(dump_minimal_yaml(eos, minimize=False))
 

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -277,7 +277,7 @@ def extract(
 
         ontogpt extract -t gocam.GoCamAnnotations -i gocam-27929086.txt
 
-    The input argument may be: 
+    The input argument may be:
         A file path,
         A directory,
         or a string.
@@ -311,7 +311,7 @@ def extract(
         inputlist.append(text)
     elif inputfile and Path(inputfile).is_dir():
         logging.info(f"Input file directory: {inputfile}")
-        inputfiles = Path(inputfile).glob('*.txt')
+        inputfiles = Path(inputfile).glob("*.txt")
         inputlist = [open(f, "r").read() for f in inputfiles if f.is_file()]
         logging.info(f"Found {len(inputlist)} input files here.")
     elif inputfile and Path(inputfile).exists():
@@ -349,8 +349,14 @@ def extract(
     else:
         target_class_def = None
 
+    i = 0
     for input_entry in inputlist:
-        results = ke.extract_from_text(text=input_entry, cls=target_class_def, show_prompt=show_prompt)
+        if len(inputlist) > 1:
+            i = i + 1
+            logging.info(f"Now reading file {i} of {len(inputlist)}")
+        results = ke.extract_from_text(
+            text=input_entry, cls=target_class_def, show_prompt=show_prompt
+        )
         if set_slot_value:
             for slot_value in set_slot_value:
                 slot, value = slot_value.split("=")


### PR DESCRIPTION
This enables passing a path to a directory through the `-i` input command for the `extract` command.

All files with the `.txt` suffix will be parsed as inputs and outputs will be written to the same output file.