### PR TITLE
Add rdf to prefixes on templates to avoid extra warnings

### DIFF
--- a/src/ontogpt/templates/biological_process.yaml
+++ b/src/ontogpt/templates/biological_process.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for GO-CAMs
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_
   CL: http://purl.obolibrary.org/obo/CL_
   GO: http://purl.obolibrary.org/obo/GO_

--- a/src/ontogpt/templates/biotic_interaction.yaml
+++ b/src/ontogpt/templates/biotic_interaction.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for biotic interactions
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   MESH: http://identifiers.org/mesh/
   NCBITaxon: http://purl.obolibrary.org/obo/NCBITAXON_
   RO: http://purl.obolibrary.org/obo/RO_

--- a/src/ontogpt/templates/cell_type.yaml
+++ b/src/ontogpt/templates/cell_type.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for representing cell types
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   AUTO: http://w3id.org/ontogpt/auto/
   BFO: http://purl.obolibrary.org/obo/BFO_
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_

--- a/src/ontogpt/templates/class_enrichment.yaml
+++ b/src/ontogpt/templates/class_enrichment.yaml
@@ -6,6 +6,7 @@ description: >-
 license: https://creativecommons.org/publicdomain/zero/1.0/
 
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   OBI: http://purl.obolibrary.org/obo/OBI_
   STATO: http://purl.obolibrary.org/obo/STATO_
   bpa: https://bioportal.bioontology.org/annotator/

--- a/src/ontogpt/templates/composite_disease.yaml
+++ b/src/ontogpt/templates/composite_disease.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for representing composite disease concepts
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_
   HGNC: http://identifiers.org/hgnc/
   HP: http://purl.obolibrary.org/obo/HP_

--- a/src/ontogpt/templates/core.yaml
+++ b/src/ontogpt/templates/core.yaml
@@ -3,6 +3,7 @@ name: core
 title: AI core Template
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   NCIT: http://purl.obolibrary.org/obo/NCIT_
   RO: http://purl.obolibrary.org/obo/RO_
   biolink: https://w3id.org/biolink/vocab/

--- a/src/ontogpt/templates/ctd.yaml
+++ b/src/ontogpt/templates/ctd.yaml
@@ -13,6 +13,7 @@ see_also:
 source: https://biocreative.bioinformatics.udel.edu/tasks/biocreative-v/track-3-cdr/
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   MESH: http://identifiers.org/mesh/
   drug: http://w3id.org/ontogpt/drug/
   linkml: https://w3id.org/linkml/

--- a/src/ontogpt/templates/ctd_ner.yaml
+++ b/src/ontogpt/templates/ctd_ner.yaml
@@ -15,6 +15,7 @@ source: >-
   https://biocreative.bioinformatics.udel.edu/tasks/biocreative-v/track-3-cdr/
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   MESH: http://identifiers.org/mesh/
   ctdner: http://w3id.org/ontogpt/ctd_ner
   linkml: https://w3id.org/linkml/

--- a/src/ontogpt/templates/data_sheets_schema.yaml
+++ b/src/ontogpt/templates/data_sheets_schema.yaml
@@ -9,6 +9,7 @@ see_also:
   - https://bridge2ai.github.io/data-sheets-schema
 
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   biolink: https://w3id.org/biolink/
   csvw: http://www.w3.org/ns/csvw#
   data_sheets_schema: https://w3id.org/bridge2ai/data-sheets-schema/

--- a/src/ontogpt/templates/datasheet.py
+++ b/src/ontogpt/templates/datasheet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -46,14 +48,14 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Dataset(NamedEntity):
     """
@@ -72,20 +74,20 @@ class Dataset(NamedEntity):
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Organization(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -98,7 +100,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -107,7 +109,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -116,14 +118,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -133,7 +135,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -141,7 +143,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/datasheet.yaml
+++ b/src/ontogpt/templates/datasheet.yaml
@@ -10,6 +10,7 @@ description: >-
 
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   d4d: http://w3id.org/ontogpt/datasheet
 

--- a/src/ontogpt/templates/desiccation.py
+++ b/src/ontogpt/templates/desiccation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -46,14 +48,14 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class EntityContainingDocument(NamedEntity):
     
@@ -63,34 +65,34 @@ class EntityContainingDocument(NamedEntity):
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class EnvironmentalCondition(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Taxon(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Trait(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -103,7 +105,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -112,7 +114,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -121,14 +123,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -138,7 +140,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -146,7 +148,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/desiccation.yaml
+++ b/src/ontogpt/templates/desiccation.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for extracting ChEBI, GO, NCBITAXON, PO, TO, PECO
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   desiccation: http://w3id.org/ontogpt/desiccation
 

--- a/src/ontogpt/templates/diagnostic_procedure.yaml
+++ b/src/ontogpt/templates/diagnostic_procedure.yaml
@@ -6,6 +6,7 @@ description: >-
   phenotypes they may contribute to.
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   HP: http://purl.obolibrary.org/obo/HP_
   LOINC: http://loinc.org/rdf/
   OBA: http://purl.obolibrary.org/obo/OBA_

--- a/src/ontogpt/templates/dietitian_notes.yaml
+++ b/src/ontogpt/templates/dietitian_notes.yaml
@@ -7,6 +7,7 @@ description: >-
   and Alyson Lawrence, RD, CNSC
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   EFO: http://www.ebi.ac.uk/efo/EFO_
   FOODON: http://purl.obolibrary.org/obo/FOODON_
   HP: http://purl.obolibrary.org/obo/HP_

--- a/src/ontogpt/templates/drug.yaml
+++ b/src/ontogpt/templates/drug.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for Drugs and drug mechanism
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   HGNC: http://identifiers.org/hgnc/
   MESH: http://identifiers.org/mesh/
   drug: http://w3id.org/ontogpt/drug/

--- a/src/ontogpt/templates/emapa_simple.yaml
+++ b/src/ontogpt/templates/emapa_simple.yaml
@@ -5,6 +5,7 @@ description: >-
   Simple Mouse Developmental Anatomy Ontology Extraction Template
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   EMAPA: http://purl.obolibrary.org/obo/EMAPA_
   GO: http://purl.obolibrary.org/obo/GO_
   emapa_simple: http://w3id.org/ontogpt/emapa_simple

--- a/src/ontogpt/templates/environmental_metadata.yaml
+++ b/src/ontogpt/templates/environmental_metadata.yaml
@@ -6,6 +6,7 @@ description: >-
   data entries. See https://github.com/EDIorg/EDIorg-repository-index
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   ENVO: http://purl.obolibrary.org/obo/ENVO_
   envmd: http://w3id.org/ontogpt/environmental-metadata
   linkml: https://w3id.org/linkml/

--- a/src/ontogpt/templates/environmental_sample.yaml
+++ b/src/ontogpt/templates/environmental_sample.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for Environmental Samples
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   ENVO: http://purl.obolibrary.org/obo/ENVO_
   PATO: http://purl.obolibrary.org/obo/PATO_
   UO: http://purl.obolibrary.org/obo/UO_

--- a/src/ontogpt/templates/figure.py
+++ b/src/ontogpt/templates/figure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -41,7 +43,7 @@ class FigureCaption(ConfiguredBaseModel):
     title: Optional[str] = Field(None, description="""the overall title of the figure caption""")
     subpanel: Optional[List[SubPanel]] = Field(default_factory=list, description="""a subpanel of the figure""")
     
-        
+    
 
 class SubPanel(ConfiguredBaseModel):
     """
@@ -51,7 +53,7 @@ class SubPanel(ConfiguredBaseModel):
     text: Optional[str] = Field(None, description="""The text associated with this figure subpanel""")
     info: Optional[str] = Field(None, description="""any information from the overall figure caption that applies to that subpanel (which may be duplicated across other subpanels).""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -65,20 +67,20 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -91,7 +93,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -100,7 +102,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -109,14 +111,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -126,7 +128,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -134,7 +136,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/figure.yaml
+++ b/src/ontogpt/templates/figure.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for Plazi figures and sub-parts
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   fig: http://w3id.org/ontogpt/figure-template
 

--- a/src/ontogpt/templates/gene_description_term.yaml
+++ b/src/ontogpt/templates/gene_description_term.yaml
@@ -5,6 +5,7 @@ description: >-
   A simple GO term template for NER
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   GO: http://purl.obolibrary.org/obo/GO_
   HGNC: http://identifiers.org/hgnc/
   MESH: http://identifiers.org/mesh/

--- a/src/ontogpt/templates/genesummary.yaml
+++ b/src/ontogpt/templates/genesummary.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for genesummary
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   CL: http://purl.obolibrary.org/obo/CL_
   GO: http://purl.obolibrary.org/obo/GO_
   HGNC: http://identifiers.org/hgnc/

--- a/src/ontogpt/templates/go_simple.py
+++ b/src/ontogpt/templates/go_simple.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -46,14 +48,14 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class OntologyTermSet(NamedEntity):
     
@@ -61,20 +63,20 @@ class OntologyTermSet(NamedEntity):
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class OntologyTerm(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -87,7 +89,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -96,7 +98,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -105,14 +107,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -122,7 +124,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -130,7 +132,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/go_simple.yaml
+++ b/src/ontogpt/templates/go_simple.yaml
@@ -5,6 +5,7 @@ description: >-
   Simple Gene Ontology Extraction Template
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   go_simple: http://w3id.org/ontogpt/go_simple
   GO: http://purl.obolibrary.org/obo/GO_

--- a/src/ontogpt/templates/go_terms.py
+++ b/src/ontogpt/templates/go_terms.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class GOBiologicalProcessType(str):
@@ -64,41 +66,41 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class BiologicalProcess(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CellularComponent(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class MolecularFunction(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -111,7 +113,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -120,7 +122,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -129,7 +131,7 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class Document(TextWithEntity):
     """
@@ -141,14 +143,14 @@ class Document(TextWithEntity):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -158,7 +160,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -166,7 +168,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/go_terms.yaml
+++ b/src/ontogpt/templates/go_terms.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for GO Term and ID extraction.
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   go_terms: http://w3id.org/ontogpt/go_terms
 

--- a/src/ontogpt/templates/go_terms_relational.py
+++ b/src/ontogpt/templates/go_terms_relational.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -46,34 +48,34 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Protein(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class GOTerm(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -86,7 +88,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class ProteinToGORelationship(Triple):
     """
@@ -99,7 +101,7 @@ class ProteinToGORelationship(Triple):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the protein.""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the GO term.""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -108,7 +110,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class Document(TextWithTriples):
     """
@@ -117,7 +119,7 @@ class Document(TextWithTriples):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[ProteinToGORelationship]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -126,14 +128,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class ProteinToGOPredicate(RelationshipType):
     """
@@ -142,7 +144,7 @@ class ProteinToGOPredicate(RelationshipType):
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -152,7 +154,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -160,7 +162,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/go_terms_relational.yaml
+++ b/src/ontogpt/templates/go_terms_relational.yaml
@@ -8,6 +8,7 @@ description: >-
   GO term types.
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   go_terms_relational: http://w3id.org/ontogpt/go_terms_relational
 

--- a/src/ontogpt/templates/gocam.yaml
+++ b/src/ontogpt/templates/gocam.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for GO-CAMs
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_
   CL: http://purl.obolibrary.org/obo/CL_
   EFO: http://www.ebi.ac.uk/efo/EFO_

--- a/src/ontogpt/templates/halo.py
+++ b/src/ontogpt/templates/halo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -38,7 +40,7 @@ class Ontology(ConfiguredBaseModel):
     
     elements: Optional[List[OntologyElement]] = Field(default_factory=list)
     
-        
+    
 
 class OntologyElement(ConfiguredBaseModel):
     
@@ -53,7 +55,7 @@ class OntologyElement(ConfiguredBaseModel):
     parts: Optional[List[str]] = Field(default_factory=list, description="""a list of names of things this element has as parts (components)""")
     equivalent_to: Optional[str] = Field(None, description="""an OWL class expression with the necessary and sufficient conditions for this entity to be an instance of this class""")
     
-        
+    
 
 class Category(OntologyElement):
     
@@ -68,7 +70,7 @@ class Category(OntologyElement):
     parts: Optional[List[str]] = Field(default_factory=list, description="""a list of names of things this element has as parts (components)""")
     equivalent_to: Optional[str] = Field(None, description="""an OWL class expression with the necessary and sufficient conditions for this entity to be an instance of this class""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -82,20 +84,20 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -108,7 +110,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -117,7 +119,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -126,14 +128,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -143,7 +145,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -151,7 +153,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/halo.yaml
+++ b/src/ontogpt/templates/halo.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for Ontology Classes
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   oc: http://w3id.org/ontogpt/ontology-class-template
   BFO: http://purl.obolibrary.org/obo/BFO_

--- a/src/ontogpt/templates/human_phenotype.yaml
+++ b/src/ontogpt/templates/human_phenotype.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for extracting human phenotypes to HPO terms
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   HP: http://purl.obolibrary.org/obo/HP_
   human_phenotype: http://w3id.org/ontogpt/human_phenotype
   linkml: https://w3id.org/linkml/

--- a/src/ontogpt/templates/ibd.py
+++ b/src/ontogpt/templates/ibd.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class GeneLocationEnum(str):
@@ -64,7 +66,7 @@ class IBDAnnotations(ConfiguredBaseModel):
     gene_gene_interactions: Optional[List[GeneGeneInteraction]] = Field(default_factory=list, description="""semicolon-separated list of gene to gene interactions""")
     gene_localizations: Optional[List[GeneSubcellularLocalizationRelationship]] = Field(default_factory=list, description="""semicolon-separated list of genes plus their location in the cell; for example, \"gene1 / cytoplasm; gene2 / mitochondrion\"""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -78,83 +80,83 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Gene(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Pathway(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CellularProcess(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class MolecularActivity(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class GeneLocation(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Organism(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Molecule(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class GeneOrganismRelationship(CompoundExpression):
     
     gene: Optional[str] = Field(None)
     organism: Optional[str] = Field(None)
     
-        
+    
 
 class GeneMolecularActivityRelationship(CompoundExpression):
     
     gene: Optional[str] = Field(None)
     molecular_activity: Optional[str] = Field(None)
     
-        
+    
 
 class GeneMolecularActivityRelationship2(CompoundExpression):
     
@@ -162,21 +164,21 @@ class GeneMolecularActivityRelationship2(CompoundExpression):
     molecular_activity: Optional[str] = Field(None)
     target: Optional[str] = Field(None)
     
-        
+    
 
 class GeneSubcellularLocalizationRelationship(CompoundExpression):
     
     gene: Optional[str] = Field(None)
     location: Optional[str] = Field(None)
     
-        
+    
 
 class GeneGeneInteraction(CompoundExpression):
     
     gene1: Optional[str] = Field(None)
     gene2: Optional[str] = Field(None)
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -189,7 +191,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -198,7 +200,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -207,14 +209,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -224,7 +226,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -232,7 +234,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/ibd.yaml
+++ b/src/ontogpt/templates/ibd.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for GO-CAMs
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   gocam: http://w3id.org/ontogpt/gocam/
   GO: http://purl.obolibrary.org/obo/GO_

--- a/src/ontogpt/templates/ibd_literature.py
+++ b/src/ontogpt/templates/ibd_literature.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -43,7 +45,7 @@ class IBDAnnotations(ConfiguredBaseModel):
     cellular_process: Optional[List[str]] = Field(default_factory=list, description="""semicolon-separated list of cellular processes""")
     disease_cellular_process_relationships: Optional[List[DiseaseCellularProcessRelationship]] = Field(default_factory=list, description="""semicolon-separated list of disease to cellular process relationships""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -57,62 +59,62 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Gene(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class ChemicalExposure(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class ChemicalExposureToGenePredicate(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Disease(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CellularProcess(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class DiseaseToCellularProcessPredicate(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class GeneExposureRelationship(CompoundExpression):
     
@@ -122,7 +124,7 @@ class GeneExposureRelationship(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the chemical exposure.""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the gene.""")
     
-        
+    
 
 class DiseaseCellularProcessRelationship(CompoundExpression):
     
@@ -132,7 +134,7 @@ class DiseaseCellularProcessRelationship(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None)
     object_qualifier: Optional[str] = Field(None)
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -145,7 +147,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -154,7 +156,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -163,14 +165,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -180,7 +182,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -188,7 +190,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/ibd_literature.yaml
+++ b/src/ontogpt/templates/ibd_literature.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for extracting information from IBD literature
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_
   ECTO: http://purl.obolibrary.org/obo/ECTO_
   ExO: http://purl.obolibrary.org/obo/ExO_

--- a/src/ontogpt/templates/kidney.py
+++ b/src/ontogpt/templates/kidney.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -39,7 +41,7 @@ class KidneyAnnotations(ConfiguredBaseModel):
     cell_type: Optional[List[str]] = Field(default_factory=list)
     gene: Optional[List[str]] = Field(default_factory=list, description="""A gene""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -53,34 +55,34 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CellType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Gene(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -93,7 +95,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -102,7 +104,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -111,14 +113,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -128,7 +130,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -136,7 +138,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/kidney.yaml
+++ b/src/ontogpt/templates/kidney.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for extracting kidney info from literature
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   kidney: http://w3id.org/ontogpt/kidney-template
 

--- a/src/ontogpt/templates/maxo.yaml
+++ b/src/ontogpt/templates/maxo.yaml
@@ -6,6 +6,7 @@ description: >-
   MAXO medical action ontology.
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   HP: http://purl.obolibrary.org/obo/HP_
   MAXO: http://purl.obolibrary.org/obo/MAXO_
   MONDO: http://purl.obolibrary.org/obo/MONDO_

--- a/src/ontogpt/templates/mendelian_disease.yaml
+++ b/src/ontogpt/templates/mendelian_disease.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for GO-CAMs
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   HGNC: http://identifiers.org/hgnc/
   HP: http://purl.obolibrary.org/obo/HP_
   MONDO: http://purl.obolibrary.org/obo/MONDO_

--- a/src/ontogpt/templates/metabolic_process.py
+++ b/src/ontogpt/templates/metabolic_process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -46,14 +48,14 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class MetabolicProcess(NamedEntity):
     
@@ -66,27 +68,27 @@ class MetabolicProcess(NamedEntity):
     outputs: Optional[List[str]] = Field(default_factory=list, description="""the outputs of the metabolic process""")
     id: str = Field(..., description="""A unique identifier for the named entity""")
     
-        
+    
 
 class MetabolicProcessCategory(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class ChemicalEntity(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -99,7 +101,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -108,7 +110,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -117,14 +119,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -134,7 +136,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -142,7 +144,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/metabolic_process.yaml
+++ b/src/ontogpt/templates/metabolic_process.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for GO-CAMs
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   bp: http://w3id.org/ontogpt/metabolic-process-template
 

--- a/src/ontogpt/templates/metagenome_study.py
+++ b/src/ontogpt/templates/metagenome_study.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -46,7 +48,7 @@ class Study(ConfiguredBaseModel):
     sequencing_technologies: Optional[str] = Field(None)
     organisms: Optional[List[str]] = Field(default_factory=list, description="""semicolon-separated list of all studied organism taxons""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -60,90 +62,90 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Location(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class EnvironmentalMaterial(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Environment(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Variable(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Unit(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class SequencingTechnology(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Treatment(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Organism(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Measurement(CompoundExpression):
     
     value: Optional[str] = Field(None, description="""the value of the measurement""")
     unit: Optional[str] = Field(None, description="""the unit of the measurement""")
     
-        
+    
 
 class CausalRelationship(CompoundExpression):
     
     cause: Optional[str] = Field(None, description="""the variable that is the cause of the effect""")
     effect: Optional[str] = Field(None, description="""the things that is affected""")
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -156,7 +158,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -165,7 +167,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -174,14 +176,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -191,7 +193,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -199,7 +201,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/metagenome_study.yaml
+++ b/src/ontogpt/templates/metagenome_study.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for Environmental Metagenome Studies
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   eg: http://w3id.org/ontogpt/environmental-metagenome/
 

--- a/src/ontogpt/templates/mondo_simple.yaml
+++ b/src/ontogpt/templates/mondo_simple.yaml
@@ -5,6 +5,7 @@ description: >-
   Simple MONDO Disease Ontology Extraction Template
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   MONDO: http://purl.obolibrary.org/obo/MONDO_
   linkml: https://w3id.org/linkml/
   mondo_simple: http://w3id.org/ontogpt/emapa_simple

--- a/src/ontogpt/templates/nmdc_schema_data.py
+++ b/src/ontogpt/templates/nmdc_schema_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -40,7 +42,7 @@ class Dataset(ConfiguredBaseModel):
     environmental_material: Optional[List[str]] = Field(default_factory=list, description="""the environmental material that was sampled""")
     environments: Optional[List[str]] = Field(default_factory=list, description="""the environmental context in which the study was conducted""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -54,34 +56,34 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class EnvironmentalMaterial(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Environment(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -94,7 +96,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -103,7 +105,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -112,14 +114,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -129,7 +131,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -137,7 +139,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/nmdc_schema_data.yaml
+++ b/src/ontogpt/templates/nmdc_schema_data.yaml
@@ -8,6 +8,7 @@ description: >-
   of NLCD values and FAO soil taxonomy classes to ENVO.
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   nmdcsd: http://w3id.org/ontogpt/nmdc-schema-data
 

--- a/src/ontogpt/templates/ontology_class.py
+++ b/src/ontogpt/templates/ontology_class.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -40,7 +42,7 @@ class LogicalDefinition(ConfiguredBaseModel):
     differentiating_characteristic_relationship: Optional[str] = Field(None)
     differentiating_characteristic_parents: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -54,14 +56,14 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class OntologyClass(NamedEntity):
     
@@ -73,20 +75,20 @@ class OntologyClass(NamedEntity):
     logical_definition: Optional[LogicalDefinition] = Field(None, description="""the necessary and sufficient conditions for this entity to be an instance of this class""")
     id: str = Field(..., description="""A unique identifier for the named entity""")
     
-        
+    
 
 class Relation(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -99,7 +101,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -108,7 +110,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -117,14 +119,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -134,7 +136,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -142,7 +144,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/ontology_class.yaml
+++ b/src/ontogpt/templates/ontology_class.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for Ontology Classes
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   oc: http://w3id.org/ontogpt/ontology-class-template
 

--- a/src/ontogpt/templates/ontology_issue.py
+++ b/src/ontogpt/templates/ontology_issue.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class ProblemType(str, Enum):
@@ -77,7 +79,7 @@ class OntologyIssue(ConfiguredBaseModel):
     problem_list: Optional[List[OntologyProblem]] = Field(default_factory=list, description="""A list of problems stated at a high level""")
     proposed_changes: Optional[List[OntologyChange]] = Field(default_factory=list, description="""What part of the ontology does this pertain to.""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -91,27 +93,27 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class OntologyClass(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class OntologyProblem(CompoundExpression):
     
@@ -120,7 +122,7 @@ class OntologyProblem(CompoundExpression):
     category: Optional[ProblemType] = Field(None, description="""What category does this problem fall into?""")
     about: Optional[List[str]] = Field(default_factory=list, description="""What terms in the ontology is this problem about?""")
     
-        
+    
 
 class OntologyChange(CompoundExpression):
     
@@ -128,7 +130,7 @@ class OntologyChange(CompoundExpression):
     category: Optional[ChangeType] = Field(None, description="""What kind of change?""")
     about: Optional[List[str]] = Field(default_factory=list, description="""What terms in the ontology will this change affect?""")
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -141,7 +143,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -150,7 +152,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -159,14 +161,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -176,7 +178,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -184,7 +186,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/ontology_issue.yaml
+++ b/src/ontogpt/templates/ontology_issue.yaml
@@ -5,6 +5,7 @@ description: >-
   A data model for representing the contents of a GitHub issue on an ontology tracker
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   oc: http://w3id.org/ontogpt/ontology-class-template
 

--- a/src/ontogpt/templates/phenotype.yaml
+++ b/src/ontogpt/templates/phenotype.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for Computational Phenotypes
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_
   PATO: http://purl.obolibrary.org/obo/PATO_
   PR: http://purl.obolibrary.org/obo/PR_

--- a/src/ontogpt/templates/reaction.yaml
+++ b/src/ontogpt/templates/reaction.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for reactions
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_
   ECO: http://purl.obolibrary.org/obo/ECO_
   GO: http://purl.obolibrary.org/obo/GO_

--- a/src/ontogpt/templates/recipe.py
+++ b/src/ontogpt/templates/recipe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -43,7 +45,7 @@ class Recipe(ConfiguredBaseModel):
     ingredients: Optional[List[Ingredient]] = Field(default_factory=list, description="""a semicolon separated list of the ingredients plus quantities of the recipe""")
     steps: Optional[List[Step]] = Field(default_factory=list, description="""a semicolon separated list of the individual steps involved in this recipe""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -57,69 +59,69 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class FoodType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class RecipeCategory(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Action(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class UtensilType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Unit(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Ingredient(CompoundExpression):
     
     food_item: Optional[FoodItem] = Field(None, description="""the food item""")
     amount: Optional[Quantity] = Field(None, description="""the quantity of the ingredient, e.g. 2 lbs""")
     
-        
+    
 
 class Quantity(CompoundExpression):
     
     value: Optional[str] = Field(None, description="""the value of the quantity""")
     unit: Optional[str] = Field(None, description="""the unit of the quantity, e.g. grams, cups, etc.""")
     
-        
+    
 
 class Step(CompoundExpression):
     
@@ -128,14 +130,14 @@ class Step(CompoundExpression):
     outputs: Optional[List[FoodItem]] = Field(default_factory=list, description="""a semicolon separated list of the outputs of this step""")
     utensils: Optional[List[str]] = Field(default_factory=list, description="""the kitchen utensil used in this step (e.g. pan, bowl)""")
     
-        
+    
 
 class FoodItem(CompoundExpression):
     
     food: Optional[str] = Field(None, description="""the food item""")
     state: Optional[str] = Field(None, description="""the state of the food item (e.g. chopped, diced)""")
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -148,7 +150,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -157,7 +159,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -166,14 +168,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -183,7 +185,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -191,7 +193,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/recipe.yaml
+++ b/src/ontogpt/templates/recipe.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for food recipes
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   recipe: http://w3id.org/ontogpt/recipe/
   FOODON: http://purl.obolibrary.org/obo/FOODON_

--- a/src/ontogpt/templates/traits.py
+++ b/src/ontogpt/templates/traits.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from datetime import datetime, date
 from enum import Enum
+
 from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
@@ -21,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
         extra = 'forbid',
         arbitrary_types_allowed=True,
         use_enum_values = True)
+    pass
 
 
 class NullDataOptions(str, Enum):
@@ -46,7 +48,7 @@ class Taxon(ConfiguredBaseModel):
     phenotypic_plasticiticy_traits: Optional[List[str]] = Field(default_factory=list, description="""The phenotypic plasticiticy traits for the taxon.""")
     preferred_environments: Optional[List[str]] = Field(default_factory=list, description="""The preferred environments for the taxon.""")
     
-        
+    
 
 class ExtractionResult(ConfiguredBaseModel):
     """
@@ -60,27 +62,27 @@ class ExtractionResult(ConfiguredBaseModel):
     extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
     named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
     
-        
+    
 
 class NamedEntity(ConfiguredBaseModel):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Trait(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class CompoundExpression(ConfiguredBaseModel):
     
     None
     
-        
+    
 
 class Triple(CompoundExpression):
     """
@@ -93,7 +95,7 @@ class Triple(CompoundExpression):
     subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
     object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
     
-        
+    
 
 class TextWithTriples(ConfiguredBaseModel):
     """
@@ -102,7 +104,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     triples: Optional[List[Triple]] = Field(default_factory=list)
     
-        
+    
 
 class TextWithEntity(ConfiguredBaseModel):
     """
@@ -111,14 +113,14 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(None)
     entities: Optional[List[str]] = Field(default_factory=list)
     
-        
+    
 
 class RelationshipType(NamedEntity):
     
     id: str = Field(..., description="""A unique identifier for the named entity""")
     label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
     
-        
+    
 
 class Publication(ConfiguredBaseModel):
     
@@ -128,7 +130,7 @@ class Publication(ConfiguredBaseModel):
     combined_text: Optional[str] = Field(None)
     full_text: Optional[str] = Field(None, description="""The full text of the publication""")
     
-        
+    
 
 class AnnotatorResult(ConfiguredBaseModel):
     
@@ -136,7 +138,7 @@ class AnnotatorResult(ConfiguredBaseModel):
     object_id: Optional[str] = Field(None)
     object_text: Optional[str] = Field(None)
     
-        
+    
 
 
 # Model rebuild

--- a/src/ontogpt/templates/traits.yaml
+++ b/src/ontogpt/templates/traits.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for Traits
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   linkml: https://w3id.org/linkml/
   traits: http://w3id.org/ontogpt/traits/
 

--- a/src/ontogpt/templates/treatment.yaml
+++ b/src/ontogpt/templates/treatment.yaml
@@ -5,6 +5,7 @@ description: >-
   A template for MAXO treatments
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   HGNC: http://identifiers.org/hgnc/
   HP: http://purl.obolibrary.org/obo/HP_
   MAXO: http://purl.obolibrary.org/obo/MAXO_


### PR DESCRIPTION
OWL export produces warnings when rdf prefix isn't defined, so now it's in the YAML templates.