### PR TITLE
Debug relation formatting in csv_wrapper

### DIFF
--- a/src/ontogpt/io/csv_wrapper.py
+++ b/src/ontogpt/io/csv_wrapper.py
@@ -260,12 +260,16 @@ def parse_yaml_predictions(yaml_path: str, schema_path: str, root_class=None):
                 row["id"] = str(uuid.uuid4())
                 row["category"] = rel_type
                 row["provided_by"] = doc_id
+                row["predicate"] = rel_type
                 # TODO: permit n-ary relations, given we know what to do with them
                 try:
-                    for rel_part in ["subject", "predicate", "object"]:
-                        if not isinstance(rel[rel_part], str):
+                    for i, rel_part in enumerate(rel.values()):
+                        if not isinstance(rel_part, str):
                             raise ValueError
-                        row[rel_part] = rel[rel_part]
+                        if i == 0:
+                            row["subject"] = rel_part
+                        elif i == 1:
+                            row["object"] = rel_part
                     rel_rows.append(row)
                 except KeyError:
                     logger.warning(f"Relation {rel} missing part")


### PR DESCRIPTION
Fixes #353 -- not sure how universal this fix is, so would appreciate feedback!

In particular, it seemed like the previous implementation assumed that the relation dictionaries would have the keys `"subject", "predicate", "object"`, which at least in the case of the schema I've been working with, isn't the case; the relation dictionary keys are entity types, and there's no entry for the predicate.

For the moment, I just used the `rel_type` as the predicate in addition to the category; previously I had converted the lowercase&pluralized `rel_type` to the camelcase&singular relation type from the schema with a function that didn't use SchemaView; I assume using SchemaView is what I should do here, but for some reason, my SchemaView seems to be empty, even though my schema is properly formatted (at least, I assume it is since it works when I run `ontogpt extract`!).

The `try/except` needs to be updated to catch n-ary relations -- just wanted to wait to do that until I was sure the initial changes were good.

Thanks!