### PR TITLE
Fix issue with early termination of multilanguage analysis runs

### DIFF
--- a/src/ontogpt/utils/multilingual.py
+++ b/src/ontogpt/utils/multilingual.py
@@ -76,6 +76,17 @@ def multilingual_analysis(
                     for pred in predictions:
                         pred_ids[filename].append(pred.id)
                         pred_names[filename].append(pred.label)
+
+                    # Log the result
+                    logging.info(
+                        "input file name"
+                        "\tpredicted diagnosis ids\tpredicted diagnosis names\n"
+                    )
+                    logging.info(
+                        f'{filename}'
+                        f'\t{"|".join(pred_ids[filename])}'
+                        f'\t{"|".join(pred_names[filename])}\n'
+                    )
                     grounded = True
                 except Exception as e:
                     errors[filename] = e
@@ -90,17 +101,6 @@ def multilingual_analysis(
                     outfile.write(gpt_diagnosis)
                 else:
                     outfile.write(f"Error: {errors[filename]}")
-
-            # Log the result
-            logging.info(
-                "input file name"
-                "\tpredicted diagnosis ids\tpredicted diagnosis names\n"
-            )
-            logging.info(
-                f'{filename}'
-                f'\t{"|".join(pred_ids[filename])}'
-                f'\t{"|".join(pred_names[filename])}\n'
-            )
 
             # Write the result
             # Include the input filename for the prompt in the output

--- a/src/ontogpt/utils/multilingual.py
+++ b/src/ontogpt/utils/multilingual.py
@@ -63,19 +63,23 @@ def multilingual_analysis(
             # to ground the answer to OMIM (using MONDO, etc)
             # The KE is refreshed here to avoid retaining
             if completed:
-                ke = SPIRESEngine(
-                    template_details=template_details,
-                    model=model,
-                    model_source="openai",
-                )
-                extraction = ke.extract_from_text(text=gpt_diagnosis)
-                predictions = extraction.named_entities
-                pred_ids[filename] = []
-                pred_names[filename] = []
-                for pred in predictions:
-                    pred_ids[filename].append(pred.id)
-                    pred_names[filename].append(pred.label)
-                grounded = True
+                try:
+                    ke = SPIRESEngine(
+                        template_details=template_details,
+                        model=model,
+                        model_source="openai",
+                    )
+                    extraction = ke.extract_from_text(text=gpt_diagnosis)
+                    predictions = extraction.named_entities
+                    pred_ids[filename] = []
+                    pred_names[filename] = []
+                    for pred in predictions:
+                        pred_ids[filename].append(pred.id)
+                        pred_names[filename].append(pred.label)
+                    grounded = True
+                except Exception as e:
+                    errors[filename] = e
+                    logging.error(f"Error: {e}")
 
             # Retain the output as text
             # Create the output filename based on the input filename

--- a/src/ontogpt/utils/multilingual.py
+++ b/src/ontogpt/utils/multilingual.py
@@ -49,11 +49,13 @@ def multilingual_analysis(
                 prompt = txt_file.read()
 
             # TODO: attempt to retry the request if it fails
+            #       or rather, ensure the OpenAI client does this as expected
+            # TODO: ensure the OpenAI client lets us know about errors as expected
 
             try:
                 gpt_diagnosis = ai.complete(prompt)
                 completed = True
-            except openai.error.InvalidRequestError as e:
+            except Exception as e:
                 errors[filename] = e
                 logging.error(f"Error: {e}")
 

--- a/src/ontogpt/utils/multilingual.py
+++ b/src/ontogpt/utils/multilingual.py
@@ -99,14 +99,15 @@ def multilingual_analysis(
             with open(output_file_path, "w", encoding="utf-8") as outfile:
                 if completed and grounded:
                     outfile.write(gpt_diagnosis)
+
+                    # Write the result
+                    # Include the input filename for the prompt in the output
+                    extraction.extracted_object.label = filename
+                    output.write("---\n")
+                    output.write(dump_minimal_yaml(extraction))
+
                 else:
                     outfile.write(f"Error: {errors[filename]}")
-
-            # Write the result
-            # Include the input filename for the prompt in the output
-            extraction.extracted_object.label = filename
-            output.write("---\n")
-            output.write(dump_minimal_yaml(extraction))
 
             # If there were errors, log them to a file
             if len(errors) > 0:

--- a/src/ontogpt/utils/multilingual.py
+++ b/src/ontogpt/utils/multilingual.py
@@ -5,16 +5,14 @@ import logging
 import os
 from io import TextIOWrapper
 
-import openai
 
 from ontogpt.clients import OpenAIClient
 from ontogpt.engines.spires_engine import SPIRESEngine
 from ontogpt.io.template_loader import get_template_details
 from ontogpt.io.yaml_wrapper import dump_minimal_yaml
 
-def multilingual_analysis(
-    input_data_dir, output_directory, output, model="gpt-4-turbo"
-):
+
+def multilingual_analysis(input_data_dir, output_directory, output, model="gpt-4-turbo"):
     """Run the multilingual analysis."""
     # Set up the extraction template
     template = "all_disease_grounding"
@@ -79,11 +77,10 @@ def multilingual_analysis(
 
                     # Log the result
                     logging.info(
-                        "input file name"
-                        "\tpredicted diagnosis ids\tpredicted diagnosis names\n"
+                        "input file name" "\tpredicted diagnosis ids\tpredicted diagnosis names\n"
                     )
                     logging.info(
-                        f'{filename}'
+                        f"{filename}"
                         f'\t{"|".join(pred_ids[filename])}'
                         f'\t{"|".join(pred_names[filename])}\n'
                     )


### PR DESCRIPTION
Multilanguage analysis now continues as expected if it encounters an error in prompt completion or grounding.
The output file will contain the text of the error.
All errors and prompt filenames are also written to a file named `errors.txt` in the output directory (e.g., for `malco` it's going to be in `/outputdir/raw_results/en/differentials_by_file/errors.txt`).