### PR TITLE
Add option to truncate input_text in outputs

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -149,6 +149,12 @@ The range may vary per model, but for the OpenAI API this value must range from 
 
 Higher temperatures generally correspond to greater randomness, which may be desirable.
 
+### cut-input-text
+
+Use the option `cut-input-text` to truncate all input_text in output to 1000 characters each.
+
+This can be useful when processing many inputs and/or full texts, as without this option the full input will be included.
+
 ## Functions
 
 ### categorize-mappings

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -87,10 +87,9 @@ def write_extraction(
 
         if cut_input_text:
             truncate_len = 1000
-            remaining_len = len(results.extracted_object["input_text"]) - truncate_len
-            results.extracted_object["input_text"] = (
-                results.extracted_object["input_text"][:truncate_len]
-                + f"...{remaining_len} chars not shown."
+            remaining_len = len(results.input_text) - truncate_len
+            results.input_text = (
+                results.input_text[:truncate_len] + f"...{remaining_len} chars not shown."
             )
 
         if output_format not in ["pickle"]:

--- a/src/ontogpt/cli.py
+++ b/src/ontogpt/cli.py
@@ -548,7 +548,6 @@ def iteratively_generate_extract(
 @api_base_option
 @api_version_option
 @model_provider_option
-@click.argument("search")
 @click.option(
     "--max-text-length",
     default=3000,


### PR DESCRIPTION
This is useful when processing multiple documents and/or full texts, as they can get quite large.