### PR TITLE
Add topic classifier

### DIFF
--- a/src/ontogpt/engines/topic_classifier_engine.py
+++ b/src/ontogpt/engines/topic_classifier_engine.py
@@ -1,0 +1,28 @@
+"""Topic classifier engine."""
+
+from dataclasses import dataclass
+from typing import List
+
+from ontogpt.engines.knowledge_engine import KnowledgeEngine
+
+
+@dataclass
+class TopicClassifierEngine(KnowledgeEngine):
+    """Engine for classifying input text based on its topic."""
+
+    def binary_classify(self, topic: str, text: str) -> bool:
+        """Given a topic description, indicate whether it applies to the input text."""
+
+        prompt = (
+            "I will provide a topic followed by a text."
+            " If the text matches the topic, return only 'True'."
+            " If the text does not match the topic, return only 'False'."
+            " Do not provide any other text."
+            f" Topic: {topic}"
+            f" Text: {text}"
+        )
+        payload = self.client.complete(prompt)
+        if payload.lower in ["true"]:
+            return True
+        else:
+            return False


### PR DESCRIPTION
Given an input text (or a directory of them) and a topic, this queries an LLM as to whether the text matches the topic.

Example:

```bash
$ ontogpt classify-by-topic -i temp/30091466.txt -m lbl/llama-3 --model-provider openai --api-base "https://api.cborg.lbl.gov" "clinical observations of human patients, including the diagnostic and therapeutic procedures used during their clinical care."
temp/30091466.txt       False
```