### PR TITLE
Removed `pydantic_version` keyword in template_loader.py

### DIFF
--- a/src/ontogpt/io/template_loader.py
+++ b/src/ontogpt/io/template_loader.py
@@ -45,7 +45,7 @@ def get_template_details(template: TEMPLATE_NAME) -> ClassDefinition:
 
         sv = SchemaView(new_path_to_template)
 
-        gen = PydanticGenerator(str(new_path_to_template), pydantic_version=2)
+        gen = PydanticGenerator(str(new_path_to_template))
         path_to_module.write_text(gen.serialize())
 
         mod = importlib.import_module(f"ontogpt.templates.{module_name}")


### PR DESCRIPTION
Removing `pydantic_version=2` keyword in initialization of `PydanticGenerator` object. It appears that this is an unsupported keyword argument with linkml 1.8.3 and was causing crashes in `ontogpt extract` calls. I did not test with linkml 1.8.0. Is `pydantic_version` necessary here?