### PR TITLE
Fix openapi key required for loading ollama models

### DIFF
--- a/src/ontogpt/clients/llm_client.py
+++ b/src/ontogpt/clients/llm_client.py
@@ -47,7 +47,7 @@ class LLMClient:
         # then configs handled by oaklib.
         if self.model.startswith("ollama"):
             self.api_key = ""  # Don't need an API key
-        if not self.api_key and not self.custom_llm_provider:
+        elif not self.api_key and not self.custom_llm_provider:
             self.api_key = get_apikey_value("openai")
         elif self.custom_llm_provider == "anthropic":
             self.api_key = get_apikey_value("anthropic-key")


### PR DESCRIPTION
As described in #487, currently an openai key is loaded even if the requested model starts with ollama. This PR fixes the issue for me.
