### PR TITLE
Updates for the MIC extraction template

### DIFF
--- a/src/ontogpt/templates/mic.py
+++ b/src/ontogpt/templates/mic.py
@@ -12,8 +12,6 @@ from enum import Enum
 from typing import (
     Any,
     ClassVar,
-    Dict,
-    List,
     Literal,
     Optional,
     Union
@@ -47,7 +45,7 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class LinkMLMeta(RootModel):
-    root: Dict[str, Any] = {}
+    root: dict[str, Any] = {}
     model_config = ConfigDict(frozen=True)
 
     def __getattr__(self, key:str):
@@ -113,7 +111,7 @@ class ExtractionResult(ConfiguredBaseModel):
     raw_completion_output: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'raw_completion_output', 'domain_of': ['ExtractionResult']} })
     prompt: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'prompt', 'domain_of': ['ExtractionResult']} })
     extracted_object: Optional[Any] = Field(default=None, description="""The complex objects extracted from the text""", json_schema_extra = { "linkml_meta": {'alias': 'extracted_object', 'domain_of': ['ExtractionResult']} })
-    named_entities: Optional[List[Any]] = Field(default=None, description="""Named entities extracted from the text""", json_schema_extra = { "linkml_meta": {'alias': 'named_entities', 'domain_of': ['ExtractionResult']} })
+    named_entities: Optional[list[Any]] = Field(default=None, description="""Named entities extracted from the text""", json_schema_extra = { "linkml_meta": {'alias': 'named_entities', 'domain_of': ['ExtractionResult']} })
 
 
 class NamedEntity(ConfiguredBaseModel):
@@ -129,7 +127,7 @@ class NamedEntity(ConfiguredBaseModel):
                                  'value': 'AnnotationProperty, AnnotationAssertion'}},
          'domain_of': ['NamedEntity'],
          'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'comments': ['This is determined during grounding and normalization',
                       'But is based on the full input text'],
@@ -138,13 +136,14 @@ class NamedEntity(ConfiguredBaseModel):
     @field_validator('original_spans')
     def pattern_original_spans(cls, v):
         pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
         return v
 
 
@@ -177,7 +176,7 @@ class TextWithTriples(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'publication',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'domain_of': ['TextWithTriples', 'TextWithEntity']} })
-    triples: Optional[List[Triple]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'triples', 'domain_of': ['TextWithTriples']} })
+    triples: Optional[list[Triple]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'triples', 'domain_of': ['TextWithTriples']} })
 
 
 class TextWithEntity(ConfiguredBaseModel):
@@ -189,7 +188,7 @@ class TextWithEntity(ConfiguredBaseModel):
     publication: Optional[Publication] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'publication',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'domain_of': ['TextWithTriples', 'TextWithEntity']} })
-    entities: Optional[List[str]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'entities', 'domain_of': ['TextWithEntity']} })
+    entities: Optional[list[str]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'entities', 'domain_of': ['TextWithEntity']} })
 
 
 class RelationshipType(NamedEntity):
@@ -206,7 +205,7 @@ class RelationshipType(NamedEntity):
                                  'value': 'AnnotationProperty, AnnotationAssertion'}},
          'domain_of': ['NamedEntity'],
          'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'comments': ['This is determined during grounding and normalization',
                       'But is based on the full input text'],
@@ -215,13 +214,14 @@ class RelationshipType(NamedEntity):
     @field_validator('original_spans')
     def pattern_original_spans(cls, v):
         pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
         return v
 
 
@@ -249,22 +249,32 @@ class Document(NamedEntity):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/mic', 'tree_root': True})
 
-    nutrient_to_disease_relationships: Optional[List[NutrientToDiseaseRelationship]] = Field(default=None, description="""A list of relationships between nutrients and biochemical diseases.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_disease_relationships',
+    nutrient_to_feature_relationships: Optional[list[NutrientToFeatureRelationship]] = Field(default=None, description="""A list of relationships between nutrients and biological features.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_feature_relationships',
          'annotations': {'prompt': {'tag': 'prompt',
                                     'value': 'A semicolon-separated list of '
                                              'relationships between a single nutrient '
                                              '(including vitamins, minerals, and '
-                                             'micronutrients) and a single disease. A '
-                                             'disease is any abnormal health condition '
-                                             "(e.g., Alzheimer's disease, systemic "
-                                             'lupus erythematosus, rheumatoid '
-                                             'arthritis, sickle cell anemia, Barth '
-                                             'syndrome). Provide the full text from '
-                                             'the input text describing the '
-                                             'relationship without changes or '
-                                             'summarization. Include all numbered '
-                                             'inline references contained in the '
-                                             'sentences without changes. Do not '
+                                             'micronutrients) and a single feature, '
+                                             'such as a disease, symptom, abnormality, '
+                                             'or other health status. This may include '
+                                             "diseases like Alzheimer's disease, "
+                                             'systemic lupus erythematosus, rheumatoid '
+                                             'arthritis, sickle cell anemia, or Barth '
+                                             'syndrome. It may also include phenotypes '
+                                             'such as an observable physical or '
+                                             'behavioral trait or symptom (e.g., '
+                                             'fever, headache, short attention span, '
+                                             'petechiae, telangiectasia). Phenotypes '
+                                             'do NOT include high-level biological '
+                                             'processes such as "Insulin signaling" or '
+                                             '"lipid metabolism", developmental '
+                                             'processes such as "limb development", or '
+                                             'health states such as "healthy teeth". '
+                                             'Provide the full text from the input '
+                                             'text describing the relationship without '
+                                             'changes or summarization. Include all '
+                                             'numbered inline references contained in '
+                                             'the sentences without changes. Do not '
                                              'include newlines. If multiple sentences '
                                              'describe the same relationship, include '
                                              'all of them. If the text describes a '
@@ -295,54 +305,7 @@ class Document(NamedEntity):
                                                       'Vitamin A is associated with '
                                                       'bone cancer (8).'}},
          'domain_of': ['Document']} })
-    nutrient_to_phenotype_relationships: Optional[List[NutrientToPhenotypeRelationship]] = Field(default=None, description="""A list of relationships between nutrients and biological phenotypes.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_phenotype_relationships',
-         'annotations': {'prompt': {'tag': 'prompt',
-                                    'value': 'A semicolon-separated list of '
-                                             'relationships between a single nutrient '
-                                             '(including vitamins, minerals, and '
-                                             'micronutrients) and a single biological '
-                                             'phenotype, with a type of relationship '
-                                             'connecting them both. A phenotype is an '
-                                             'observable physical or behavioral trait '
-                                             'or symptom (e.g., fever, headache, short '
-                                             'attention span, petechiae, '
-                                             'telangiectasia). It may or may not be '
-                                             'associated with a disease. Phenotypes do '
-                                             'NOT include high-level biological '
-                                             'processes such as "Insulin signaling" or '
-                                             '"lipid metabolism", developmental '
-                                             'processes such as "limb development", or '
-                                             'health states such as "healthy teeth". '
-                                             'Provide the full text from the input '
-                                             'text describing the relationship without '
-                                             'changes or summarization. Include all '
-                                             'numbered inline references contained in '
-                                             'the sentences without changes. Do not '
-                                             'include newlines. If multiple sentences '
-                                             'describe the same relationship, include '
-                                             'all of them. If the text describes a '
-                                             'one-to-many relationship, include all of '
-                                             'them separately. For example, "Vitamin A '
-                                             'is associated with fever and headache '
-                                             '(5,6)" should be "Vitamin A is '
-                                             'associated with fever (5,6); Vitamin A '
-                                             'is associated with headache (5,6)". Use '
-                                             'the same description of the relationship '
-                                             'as in the input text. For example, if '
-                                             'the input text states "Vitamin A '
-                                             'supplementation was shown to '
-                                             'successfully treat fever (5,6)", the '
-                                             'output should be "Vitamin A '
-                                             'supplementation treats fever (5,6)". '
-                                             'Other potential relationships include '
-                                             '"ameliorates" or "prevents".'},
-                         'prompt.examples': {'tag': 'prompt.examples',
-                                             'value': 'There is a relationship between '
-                                                      'Vitamin A and Fever (5). This '
-                                                      'relationship was confirmed in '
-                                                      'additional studies (6).'}},
-         'domain_of': ['Document']} })
-    nutrient_to_biological_process_relationships: Optional[List[NutrientToBiologicalProcessRelationship]] = Field(default=None, description="""A list of relationships between nutrients and biological processes.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_biological_process_relationships',
+    nutrient_to_biological_process_relationships: Optional[list[NutrientToBiologicalProcessRelationship]] = Field(default=None, description="""A list of relationships between nutrients and biological processes.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_biological_process_relationships',
          'annotations': {'prompt': {'tag': 'prompt',
                                     'value': 'A semicolon-separated list of '
                                              'relationships between a single nutrient '
@@ -392,7 +355,7 @@ class Document(NamedEntity):
                                                       'confirmed in additional studies '
                                                       '(6).'}},
          'domain_of': ['Document']} })
-    nutrient_to_health_status_relationships: Optional[List[NutrientToHealthStatusRelationship]] = Field(default=None, description="""A list of relationships between nutrients and health of a specific part or system of the human body.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_health_status_relationships',
+    nutrient_to_health_status_relationships: Optional[list[NutrientToHealthStatusRelationship]] = Field(default=None, description="""A list of relationships between nutrients and health of a specific part or system of the human body.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_health_status_relationships',
          'annotations': {'prompt': {'tag': 'prompt',
                                     'value': 'A semicolon-separated list of '
                                              'relationships between a single nutrient '
@@ -437,7 +400,7 @@ class Document(NamedEntity):
                                                       'relationship was confirmed in '
                                                       'additional studies (6).'}},
          'domain_of': ['Document']} })
-    nutrient_to_source_relationships: Optional[List[NutrientToSourceRelationship]] = Field(default=None, description="""A list of relationships between nutrients and their sources in food or supplements.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_source_relationships',
+    nutrient_to_source_relationships: Optional[list[NutrientToSourceRelationship]] = Field(default=None, description="""A list of relationships between nutrients and their sources in food or supplements.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_source_relationships',
          'annotations': {'prompt': {'tag': 'prompt',
                                     'value': 'A semicolon-separated list of '
                                              'relationships between a single nutrient '
@@ -471,7 +434,7 @@ class Document(NamedEntity):
                                                       'confirmed in additional studies '
                                                       '(13).'}},
          'domain_of': ['Document']} })
-    nutrient_to_nutrient_relationships: Optional[List[NutrientToNutrientRelationship]] = Field(default=None, description="""A list of relationships between nutrients and other nutrients.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_nutrient_relationships',
+    nutrient_to_nutrient_relationships: Optional[list[NutrientToNutrientRelationship]] = Field(default=None, description="""A list of relationships between nutrients and other nutrients.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_to_nutrient_relationships',
          'annotations': {'prompt': {'tag': 'prompt',
                                     'value': 'A semicolon-separated list of '
                                              'relationships between a single nutrient '
@@ -519,7 +482,7 @@ class Document(NamedEntity):
                                  'value': 'AnnotationProperty, AnnotationAssertion'}},
          'domain_of': ['NamedEntity'],
          'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'comments': ['This is determined during grounding and normalization',
                       'But is based on the full input text'],
@@ -528,13 +491,14 @@ class Document(NamedEntity):
     @field_validator('original_spans')
     def pattern_original_spans(cls, v):
         pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
         return v
 
 
@@ -560,7 +524,7 @@ class Nutrient(NamedEntity):
                                  'value': 'AnnotationProperty, AnnotationAssertion'}},
          'domain_of': ['NamedEntity'],
          'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'comments': ['This is determined during grounding and normalization',
                       'But is based on the full input text'],
@@ -569,26 +533,30 @@ class Nutrient(NamedEntity):
     @field_validator('original_spans')
     def pattern_original_spans(cls, v):
         pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
         return v
 
 
-class Disease(NamedEntity):
+class Feature(NamedEntity):
     """
-    The name of a disease.
+    The name of a biological feature.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'annotators': {'tag': 'annotators',
-                                        'value': 'sqlite:obo:mondo'},
+                                        'value': 'sqlite:obo:mondo, sqlite:obo:hp'},
                          'prompt': {'tag': 'prompt',
-                                    'value': 'The name of a disease.'}},
+                                    'value': 'The name of a biological feature. This '
+                                             'may include diseases, symptoms, '
+                                             'abnormalities, or other health '
+                                             'statuses.'}},
          'from_schema': 'http://w3id.org/ontogpt/mic',
-         'id_prefixes': ['MONDO']})
+         'id_prefixes': ['MONDO', 'HP']})
 
     id: str = Field(default=..., description="""A unique identifier for the named entity""", json_schema_extra = { "linkml_meta": {'alias': 'id',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
@@ -600,7 +568,7 @@ class Disease(NamedEntity):
                                  'value': 'AnnotationProperty, AnnotationAssertion'}},
          'domain_of': ['NamedEntity'],
          'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'comments': ['This is determined during grounding and normalization',
                       'But is based on the full input text'],
@@ -609,52 +577,14 @@ class Disease(NamedEntity):
     @field_validator('original_spans')
     def pattern_original_spans(cls, v):
         pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
-        return v
-
-
-class Phenotype(NamedEntity):
-    """
-    The name of a phenotype.
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'annotators': {'tag': 'annotators', 'value': 'sqlite:obo:hp'},
-                         'prompt': {'tag': 'prompt',
-                                    'value': 'The name of a phenotype.'}},
-         'from_schema': 'http://w3id.org/ontogpt/mic',
-         'id_prefixes': ['HP']})
-
-    id: str = Field(default=..., description="""A unique identifier for the named entity""", json_schema_extra = { "linkml_meta": {'alias': 'id',
-         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
-         'comments': ['this is populated during the grounding and normalization step'],
-         'domain_of': ['NamedEntity', 'Publication']} })
-    label: Optional[str] = Field(default=None, description="""The label (name) of the named thing""", json_schema_extra = { "linkml_meta": {'alias': 'label',
-         'aliases': ['name'],
-         'annotations': {'owl': {'tag': 'owl',
-                                 'value': 'AnnotationProperty, AnnotationAssertion'}},
-         'domain_of': ['NamedEntity'],
-         'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
-         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
-         'comments': ['This is determined during grounding and normalization',
-                      'But is based on the full input text'],
-         'domain_of': ['NamedEntity']} })
-
-    @field_validator('original_spans')
-    def pattern_original_spans(cls, v):
-        pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
-            for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
         return v
 
 
@@ -681,7 +611,7 @@ class BiologicalProcess(NamedEntity):
                                  'value': 'AnnotationProperty, AnnotationAssertion'}},
          'domain_of': ['NamedEntity'],
          'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'comments': ['This is determined during grounding and normalization',
                       'But is based on the full input text'],
@@ -690,13 +620,14 @@ class BiologicalProcess(NamedEntity):
     @field_validator('original_spans')
     def pattern_original_spans(cls, v):
         pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
         return v
 
 
@@ -722,7 +653,7 @@ class Anatomy(NamedEntity):
                                  'value': 'AnnotationProperty, AnnotationAssertion'}},
          'domain_of': ['NamedEntity'],
          'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'comments': ['This is determined during grounding and normalization',
                       'But is based on the full input text'],
@@ -731,13 +662,14 @@ class Anatomy(NamedEntity):
     @field_validator('original_spans')
     def pattern_original_spans(cls, v):
         pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
         return v
 
 
@@ -762,7 +694,7 @@ class FoodOrSupplement(NamedEntity):
                                  'value': 'AnnotationProperty, AnnotationAssertion'}},
          'domain_of': ['NamedEntity'],
          'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'comments': ['This is determined during grounding and normalization',
                       'But is based on the full input text'],
@@ -771,13 +703,14 @@ class FoodOrSupplement(NamedEntity):
     @field_validator('original_spans')
     def pattern_original_spans(cls, v):
         pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
         return v
 
 
@@ -789,7 +722,7 @@ class ScientificClaim(CompoundExpression):
 
     negated: Optional[str] = Field(default=None, description="""Whether the claim is negated in the text. This value must be either \"True\" if the claim is negated or \"False\" if it is not. For example, \"Vitamin A is not associated with cancer\" would be \"True\" and \"Vitamin A is associated with cancer\" would be \"False\".""", json_schema_extra = { "linkml_meta": {'alias': 'negated', 'domain_of': ['ScientificClaim']} })
     context: Optional[str] = Field(default=None, description="""The full text of this relationship.""", json_schema_extra = { "linkml_meta": {'alias': 'context', 'domain_of': ['ScientificClaim']} })
-    references: Optional[List[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
+    references: Optional[list[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
 
 
 class Relationship(NamedEntity):
@@ -814,7 +747,7 @@ class Relationship(NamedEntity):
                                  'value': 'AnnotationProperty, AnnotationAssertion'}},
          'domain_of': ['NamedEntity'],
          'slot_uri': 'rdfs:label'} })
-    original_spans: Optional[List[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
          'comments': ['This is determined during grounding and normalization',
                       'But is based on the full input text'],
@@ -823,74 +756,48 @@ class Relationship(NamedEntity):
     @field_validator('original_spans')
     def pattern_original_spans(cls, v):
         pattern=re.compile(r"^\d+:\d+$")
-        if isinstance(v,list):
+        if isinstance(v, list):
             for element in v:
-                if isinstance(v, str) and not pattern.match(element):
-                    raise ValueError(f"Invalid original_spans format: {element}")
-        elif isinstance(v,str):
-            if not pattern.match(v):
-                raise ValueError(f"Invalid original_spans format: {v}")
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
         return v
 
 
-class NutrientToDiseaseRelationship(ScientificClaim):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'comments': ['a Chemical to Disease relationship'],
+class NutrientToFeatureRelationship(ScientificClaim):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'comments': ['a Chemical to Feature relationship'],
          'from_schema': 'http://w3id.org/ontogpt/mic'})
 
     nutrient: Optional[str] = Field(default=None, description="""The name of the nutrient defined in the claim, including vitamins and minerals.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
+         'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToHealthStatusRelationship',
                        'NutrientToSourceRelationship']} })
-    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the disease.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
+    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the feature.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
+         'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',
                        'NutrientToHealthStatusRelationship',
                        'NutrientToSourceRelationship']} })
-    disease: Optional[str] = Field(default=None, description="""The name of the disease defined in the claim.""", json_schema_extra = { "linkml_meta": {'alias': 'disease', 'domain_of': ['NutrientToDiseaseRelationship']} })
+    feature: Optional[str] = Field(default=None, description="""The name of the biological feature defined in the claim.""", json_schema_extra = { "linkml_meta": {'alias': 'feature', 'domain_of': ['NutrientToFeatureRelationship']} })
     negated: Optional[str] = Field(default=None, description="""Whether the claim is negated in the text. This value must be either \"True\" if the claim is negated or \"False\" if it is not. For example, \"Vitamin A is not associated with cancer\" would be \"True\" and \"Vitamin A is associated with cancer\" would be \"False\".""", json_schema_extra = { "linkml_meta": {'alias': 'negated', 'domain_of': ['ScientificClaim']} })
     context: Optional[str] = Field(default=None, description="""The full text of this relationship.""", json_schema_extra = { "linkml_meta": {'alias': 'context', 'domain_of': ['ScientificClaim']} })
-    references: Optional[List[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
-
-
-class NutrientToPhenotypeRelationship(ScientificClaim):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'comments': ['a Chemical to Phenotype relationship'],
-         'from_schema': 'http://w3id.org/ontogpt/mic'})
-
-    nutrient: Optional[str] = Field(default=None, description="""The name of the nutrient defined in the claim, including vitamins and minerals.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
-                       'NutrientToBiologicalProcessRelationship',
-                       'NutrientToHealthStatusRelationship',
-                       'NutrientToSourceRelationship']} })
-    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the phenotype.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
-                       'NutrientToBiologicalProcessRelationship',
-                       'NutrientToNutrientRelationship',
-                       'NutrientToHealthStatusRelationship',
-                       'NutrientToSourceRelationship']} })
-    phenotype: Optional[str] = Field(default=None, description="""The name of the phenotype defined in the claim.""", json_schema_extra = { "linkml_meta": {'alias': 'phenotype', 'domain_of': ['NutrientToPhenotypeRelationship']} })
-    negated: Optional[str] = Field(default=None, description="""Whether the claim is negated in the text. This value must be either \"True\" if the claim is negated or \"False\" if it is not. For example, \"Vitamin A is not associated with cancer\" would be \"True\" and \"Vitamin A is associated with cancer\" would be \"False\".""", json_schema_extra = { "linkml_meta": {'alias': 'negated', 'domain_of': ['ScientificClaim']} })
-    context: Optional[str] = Field(default=None, description="""The full text of this relationship.""", json_schema_extra = { "linkml_meta": {'alias': 'context', 'domain_of': ['ScientificClaim']} })
-    references: Optional[List[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
+    references: Optional[list[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
 
 
 class NutrientToBiologicalProcessRelationship(ScientificClaim):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/mic'})
 
     nutrient: Optional[str] = Field(default=None, description="""The name of the nutrient defined in the claim, including vitamins and minerals.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
+         'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToHealthStatusRelationship',
                        'NutrientToSourceRelationship']} })
     relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the biological process.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
+         'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',
                        'NutrientToHealthStatusRelationship',
@@ -898,7 +805,7 @@ class NutrientToBiologicalProcessRelationship(ScientificClaim):
     process: Optional[str] = Field(default=None, description="""The name of the biological process defined in the claim.""", json_schema_extra = { "linkml_meta": {'alias': 'process', 'domain_of': ['NutrientToBiologicalProcessRelationship']} })
     negated: Optional[str] = Field(default=None, description="""Whether the claim is negated in the text. This value must be either \"True\" if the claim is negated or \"False\" if it is not. For example, \"Vitamin A is not associated with cancer\" would be \"True\" and \"Vitamin A is associated with cancer\" would be \"False\".""", json_schema_extra = { "linkml_meta": {'alias': 'negated', 'domain_of': ['ScientificClaim']} })
     context: Optional[str] = Field(default=None, description="""The full text of this relationship.""", json_schema_extra = { "linkml_meta": {'alias': 'context', 'domain_of': ['ScientificClaim']} })
-    references: Optional[List[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
+    references: Optional[list[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
 
 
 class NutrientToNutrientRelationship(ScientificClaim):
@@ -907,8 +814,7 @@ class NutrientToNutrientRelationship(ScientificClaim):
 
     nutrient_subject: Optional[str] = Field(default=None, description="""The name of a nutrient defined in the claim, including vitamins and minerals.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_subject', 'domain_of': ['NutrientToNutrientRelationship']} })
     relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient_subject and nutrient_object.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
+         'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',
                        'NutrientToHealthStatusRelationship',
@@ -916,21 +822,19 @@ class NutrientToNutrientRelationship(ScientificClaim):
     nutrient_object: Optional[str] = Field(default=None, description="""The name of a nutrient defined in the claim, including vitamins and minerals.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_object', 'domain_of': ['NutrientToNutrientRelationship']} })
     negated: Optional[str] = Field(default=None, description="""Whether the claim is negated in the text. This value must be either \"True\" if the claim is negated or \"False\" if it is not. For example, \"Vitamin A is not associated with cancer\" would be \"True\" and \"Vitamin A is associated with cancer\" would be \"False\".""", json_schema_extra = { "linkml_meta": {'alias': 'negated', 'domain_of': ['ScientificClaim']} })
     context: Optional[str] = Field(default=None, description="""The full text of this relationship.""", json_schema_extra = { "linkml_meta": {'alias': 'context', 'domain_of': ['ScientificClaim']} })
-    references: Optional[List[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
+    references: Optional[list[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
 
 
 class NutrientToHealthStatusRelationship(ScientificClaim):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/mic'})
 
     nutrient: Optional[str] = Field(default=None, description="""The name of the nutrient defined in the claim, including vitamins and minerals.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
+         'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToHealthStatusRelationship',
                        'NutrientToSourceRelationship']} })
     relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the anatomical part or system.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
+         'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',
                        'NutrientToHealthStatusRelationship',
@@ -938,21 +842,19 @@ class NutrientToHealthStatusRelationship(ScientificClaim):
     anatomy: Optional[str] = Field(default=None, description="""The name of the anatomical part or system defined in the claim.""", json_schema_extra = { "linkml_meta": {'alias': 'anatomy', 'domain_of': ['NutrientToHealthStatusRelationship']} })
     negated: Optional[str] = Field(default=None, description="""Whether the claim is negated in the text. This value must be either \"True\" if the claim is negated or \"False\" if it is not. For example, \"Vitamin A is not associated with cancer\" would be \"True\" and \"Vitamin A is associated with cancer\" would be \"False\".""", json_schema_extra = { "linkml_meta": {'alias': 'negated', 'domain_of': ['ScientificClaim']} })
     context: Optional[str] = Field(default=None, description="""The full text of this relationship.""", json_schema_extra = { "linkml_meta": {'alias': 'context', 'domain_of': ['ScientificClaim']} })
-    references: Optional[List[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
+    references: Optional[list[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
 
 
 class NutrientToSourceRelationship(ScientificClaim):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/mic'})
 
     nutrient: Optional[str] = Field(default=None, description="""The name of the nutrient defined in the claim, including vitamins and minerals.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
+         'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToHealthStatusRelationship',
                        'NutrientToSourceRelationship']} })
     relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the food or supplement. This is usually \"nutrient of\".""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
-         'domain_of': ['NutrientToDiseaseRelationship',
-                       'NutrientToPhenotypeRelationship',
+         'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',
                        'NutrientToHealthStatusRelationship',
@@ -960,7 +862,7 @@ class NutrientToSourceRelationship(ScientificClaim):
     source: Optional[str] = Field(default=None, description="""The name of the food or supplement defined in the claim.""", json_schema_extra = { "linkml_meta": {'alias': 'source', 'domain_of': ['NutrientToSourceRelationship']} })
     negated: Optional[str] = Field(default=None, description="""Whether the claim is negated in the text. This value must be either \"True\" if the claim is negated or \"False\" if it is not. For example, \"Vitamin A is not associated with cancer\" would be \"True\" and \"Vitamin A is associated with cancer\" would be \"False\".""", json_schema_extra = { "linkml_meta": {'alias': 'negated', 'domain_of': ['ScientificClaim']} })
     context: Optional[str] = Field(default=None, description="""The full text of this relationship.""", json_schema_extra = { "linkml_meta": {'alias': 'context', 'domain_of': ['ScientificClaim']} })
-    references: Optional[List[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
+    references: Optional[list[str]] = Field(default=None, description="""A semi-colon separated list of references included inline in the input, identified by number only. Multiple references may contain commas, e.g., \"(3, 4)\" and should be treated as two different values. If a range of references is provided, include all, e.g., \"(3-5)\" should become 3;4;5.""", json_schema_extra = { "linkml_meta": {'alias': 'references', 'domain_of': ['ScientificClaim']} })
 
 
 # Model rebuild
@@ -976,15 +878,13 @@ Publication.model_rebuild()
 AnnotatorResult.model_rebuild()
 Document.model_rebuild()
 Nutrient.model_rebuild()
-Disease.model_rebuild()
-Phenotype.model_rebuild()
+Feature.model_rebuild()
 BiologicalProcess.model_rebuild()
 Anatomy.model_rebuild()
 FoodOrSupplement.model_rebuild()
 ScientificClaim.model_rebuild()
 Relationship.model_rebuild()
-NutrientToDiseaseRelationship.model_rebuild()
-NutrientToPhenotypeRelationship.model_rebuild()
+NutrientToFeatureRelationship.model_rebuild()
 NutrientToBiologicalProcessRelationship.model_rebuild()
 NutrientToNutrientRelationship.model_rebuild()
 NutrientToHealthStatusRelationship.model_rebuild()

--- a/src/ontogpt/templates/mic.py
+++ b/src/ontogpt/templates/mic.py
@@ -777,7 +777,7 @@ class NutrientToFeatureRelationship(ScientificClaim):
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToHealthStatusRelationship',
                        'NutrientToSourceRelationship']} })
-    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the feature.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
+    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the feature. Choose from one of the following: \"positively correlated with\", \"negatively correlated with\", \"treats\", \"studied to treat\", \"in clinical trials for\", \"in preclinical trials for\", \"beneficial in models for\", \"applied to treat\". If none of these apply, use \"associated with\".""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
          'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',
@@ -797,7 +797,7 @@ class NutrientToBiologicalProcessRelationship(ScientificClaim):
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToHealthStatusRelationship',
                        'NutrientToSourceRelationship']} })
-    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the biological process.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
+    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the biological process. Choose from one of the following: \"interacts with\", \"physically interacts with\", \"increases amount or activity of\", \"decreases amount or activity of\", \"amount or activity increased by\", \"amount or activity decreased by\", \"response affected by\", \"increases response to\", \"decreases response to\", \"response increased by\". If none of these apply, use \"associated with\".""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
          'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',
@@ -814,7 +814,7 @@ class NutrientToNutrientRelationship(ScientificClaim):
          'from_schema': 'http://w3id.org/ontogpt/mic'})
 
     nutrient_subject: Optional[str] = Field(default=None, description="""The name of a nutrient defined in the claim, including vitamins and minerals.""", json_schema_extra = { "linkml_meta": {'alias': 'nutrient_subject', 'domain_of': ['NutrientToNutrientRelationship']} })
-    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient_subject and nutrient_object.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
+    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient_subject and nutrient_object. Choose from one of the following: \"interacts with\", \"physically interacts with\", \"increases amount or activity of\", \"decreases amount or activity of\", \"amount or activity increased by\", \"amount or activity decreased by\", \"response affected by\", \"increases response to\", \"decreases response to\", \"response increased by\". If none of these apply, use \"associated with\".""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
          'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',
@@ -834,7 +834,7 @@ class NutrientToHealthStatusRelationship(ScientificClaim):
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToHealthStatusRelationship',
                        'NutrientToSourceRelationship']} })
-    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the anatomical part or system.""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
+    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the anatomical part or system. Choose from one of the following: \"affects\", \"participates in\". If none of these apply, use \"associated with\".""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
          'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',
@@ -854,7 +854,7 @@ class NutrientToSourceRelationship(ScientificClaim):
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToHealthStatusRelationship',
                        'NutrientToSourceRelationship']} })
-    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the food or supplement. This is usually \"nutrient of\".""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
+    relationship: Optional[str] = Field(default=None, description="""The name of a type of relationship between the nutrient and the food or supplement. Choose from one of the following: \"nutrient of\", \"is active ingredient of\", \"food component of\". If none of these apply, use \"associated with\".""", json_schema_extra = { "linkml_meta": {'alias': 'relationship',
          'domain_of': ['NutrientToFeatureRelationship',
                        'NutrientToBiologicalProcessRelationship',
                        'NutrientToNutrientRelationship',

--- a/src/ontogpt/templates/mic.py
+++ b/src/ontogpt/templates/mic.py
@@ -292,9 +292,9 @@ class Document(NamedEntity):
                                              'supplementation was shown to '
                                              'successfully treat anemia (5,6)", the '
                                              'output should be "Iron supplementation '
-                                             'treats anemia (5,6)". Other potential '
-                                             'relationships include "ameliorates" or '
-                                             '"prevents".'},
+                                             'treats anemia (5,6)". Do not assign a '
+                                             'relationship type. Retain the language '
+                                             'used in the source text.'},
                          'prompt.examples': {'tag': 'prompt.examples',
                                              'value': 'Evidence suggests that '
                                                       'high-dose Vitamin A treatment '
@@ -343,11 +343,9 @@ class Document(NamedEntity):
                                              'states "Vitamin A is a participant in '
                                              'Insulin Signaling (5,6)", the output '
                                              'should be "Vitamin A participates in '
-                                             'Insulin Signaling (5,6)". Other '
-                                             'potential relationships include "is '
-                                             'input of", "is output of", "catalyzes", '
-                                             '"is substrate of", "involved in", and '
-                                             '"enables". '},
+                                             'Insulin Signaling (5,6)". Do not assign '
+                                             'a relationship type. Retain the language '
+                                             'used in the source text.'},
                          'prompt.examples': {'tag': 'prompt.examples',
                                              'value': 'There is a relationship between '
                                                       'Vitamin A and Insulin Signaling '
@@ -391,9 +389,9 @@ class Document(NamedEntity):
                                              '"Vitamin A levels are necessary for '
                                              'healthy teeth (5,6)", the output should '
                                              'be "Vitamin A participates in the health '
-                                             'of teeth (5,6)". Other potential '
-                                             'relationships include "ameliorates" or '
-                                             '"prevents".'},
+                                             'of teeth (5,6)". Do not assign a '
+                                             'relationship type. Retain the language '
+                                             'used in the source text.'},
                          'prompt.examples': {'tag': 'prompt.examples',
                                              'value': 'There is a relationship between '
                                                       'Vitamin A and Teeth (5). This '

--- a/src/ontogpt/templates/mic.yaml
+++ b/src/ontogpt/templates/mic.yaml
@@ -34,20 +34,28 @@ classes:
       A document that contains information about
       micronutrients, including vitamins and minerals.
     attributes:
-      nutrient_to_disease_relationships:
-        range: NutrientToDiseaseRelationship
+      nutrient_to_feature_relationships:
+        range: NutrientToFeatureRelationship
         multivalued: true
         description: >-
           A list of relationships between nutrients and
-          biochemical diseases.
+          biological features.
         annotations:
           prompt: >-
             A semicolon-separated list of relationships
             between a single nutrient (including vitamins,
             minerals, and micronutrients) and a single
-            disease. A disease is any abnormal health condition
-            (e.g., Alzheimer's disease, systemic lupus erythematosus,
-            rheumatoid arthritis, sickle cell anemia, Barth syndrome).
+            feature, such as a disease, symptom, abnormality,
+            or other health status. This may include diseases like
+            Alzheimer's disease, systemic lupus erythematosus,
+            rheumatoid arthritis, sickle cell anemia, or Barth syndrome.
+            It may also include phenotypes such as an observable
+            physical or behavioral trait or symptom (e.g., fever,
+            headache, short attention span, petechiae,
+            telangiectasia). Phenotypes do NOT include high-level
+            biological processes such as "Insulin signaling" or "lipid
+            metabolism", developmental processes such as "limb development",
+            or health states such as "healthy teeth".
             Provide the full text from the input text describing the relationship
             without changes or summarization. Include all numbered inline
             references contained in the sentences without changes.
@@ -65,42 +73,6 @@ classes:
             relationships include "ameliorates" or "prevents".
           prompt.examples: >-
             Evidence suggests that high-dose Vitamin A treatment may prevent Systemic Lupus Erythematosus (5,6). Further studies confirmed this finding (7); Studies have shown that Vitamin A is associated with bone cancer (8).
-      nutrient_to_phenotype_relationships:
-        range: NutrientToPhenotypeRelationship
-        multivalued: true
-        description: >-
-          A list of relationships between nutrients and
-          biological phenotypes.
-        annotations:
-          prompt: >-
-            A semicolon-separated list of relationships
-            between a single nutrient (including vitamins,
-            minerals, and micronutrients) and a single
-            biological phenotype, with a type of relationship
-            connecting them both. A phenotype is an observable
-            physical or behavioral trait or symptom (e.g., fever,
-            headache, short attention span, petechiae,
-            telangiectasia). It may or may not be associated
-            with a disease. Phenotypes do NOT include high-level
-            biological processes such as "Insulin signaling" or "lipid
-            metabolism", developmental processes such as "limb development",
-            or health states such as "healthy teeth".
-            Provide the full text from the input text describing the relationship
-            without changes or summarization. Include all numbered inline
-            references contained in the sentences without changes.
-            Do not include newlines. If multiple sentences describe the
-            same relationship, include all of them.
-            If the text describes a one-to-many relationship, include
-            all of them separately. For example, "Vitamin A is associated with
-            fever and headache (5,6)" should be "Vitamin A is associated with fever (5,6);
-            Vitamin A is associated with headache (5,6)".
-            Use the same description of the relationship as in the input text.
-            For example, if the input text states "Vitamin A supplementation
-            was shown to successfully treat fever (5,6)", the output should be
-            "Vitamin A supplementation treats fever (5,6)". Other potential
-            relationships include "ameliorates" or "prevents".
-          prompt.examples: >-
-            There is a relationship between Vitamin A and Fever (5). This relationship was confirmed in additional studies (6).
       nutrient_to_biological_process_relationships:
         range: NutrientToBiologicalProcessRelationship
         multivalued: true
@@ -244,27 +216,19 @@ classes:
         The name of a nutrient, including vitamins and
         minerals.
 
-  Disease:
+  Feature:
     is_a: NamedEntity
     description: >-
-      The name of a disease.
+      The name of a biological feature.
     id_prefixes:
       - MONDO
-    annotations:
-      annotators: sqlite:obo:mondo
-      prompt: >-
-        The name of a disease.
-
-  Phenotype:
-    is_a: NamedEntity
-    description: >-
-      The name of a phenotype.
-    id_prefixes:
       - HP
     annotations:
-      annotators: sqlite:obo:hp
+      annotators: sqlite:obo:mondo, sqlite:obo:hp
       prompt: >-
-        The name of a phenotype.
+        The name of a biological feature. This may
+        include diseases, symptoms, abnormalities, or
+        other health statuses.
 
   BiologicalProcess:
     is_a: NamedEntity
@@ -348,7 +312,7 @@ classes:
         The name of a type of relationship between two
         entities.
 
-  NutrientToDiseaseRelationship:
+  NutrientToFeatureRelationship:
     is_a: ScientificClaim
     attributes:
       nutrient:
@@ -360,33 +324,13 @@ classes:
         range: Relationship
         description: >-
           The name of a type of relationship between the
-          nutrient and the disease.
-      disease:
-        range: Disease
+          nutrient and the feature.
+      feature:
+        range: Feature
         description: >-
-          The name of the disease defined in the claim.
+          The name of the biological feature defined in the claim.
     comments:
-      - a Chemical to Disease relationship
-
-  NutrientToPhenotypeRelationship:
-    is_a: ScientificClaim
-    attributes:
-      nutrient:
-        range: Nutrient
-        description: >-
-          The name of the nutrient defined in the claim,
-          including vitamins and minerals.
-      relationship:
-        range: Relationship
-        description: >-
-          The name of a type of relationship between the
-          nutrient and the phenotype.
-      phenotype:
-        range: Phenotype
-        description: >-
-          The name of the phenotype defined in the claim.
-    comments:
-      - a Chemical to Phenotype relationship
+      - a Chemical to Feature relationship
 
   NutrientToBiologicalProcessRelationship:
     is_a: ScientificClaim

--- a/src/ontogpt/templates/mic.yaml
+++ b/src/ontogpt/templates/mic.yaml
@@ -334,6 +334,12 @@ classes:
         description: >-
           The name of a type of relationship between the
           nutrient and the feature.
+          Choose from one of the following:
+          "positively correlated with", "negatively correlated with",
+          "treats", "studied to treat", "in clinical trials for",
+          "in preclinical trials for", "beneficial in models for",
+          "applied to treat".
+          If none of these apply, use "associated with".
       feature:
         range: Feature
         description: >-
@@ -357,6 +363,13 @@ classes:
         description: >-
           The name of a type of relationship between the
           nutrient and the biological process.
+          Choose from one of the following:
+          "interacts with", "physically interacts with",
+          "increases amount or activity of", "decreases amount or activity of",
+          "amount or activity increased by", "amount or activity decreased by",
+          "response affected by", "increases response to",
+          "decreases response to", "response increased by".
+          If none of these apply, use "associated with".
       process:
         range: BiologicalProcess
         description: >-
@@ -375,6 +388,13 @@ classes:
         description: >-
           The name of a type of relationship between the
           nutrient_subject and nutrient_object.
+          Choose from one of the following:
+          "interacts with", "physically interacts with",
+          "increases amount or activity of", "decreases amount or activity of",
+          "amount or activity increased by", "amount or activity decreased by",
+          "response affected by", "increases response to",
+          "decreases response to", "response increased by".
+          If none of these apply, use "associated with".
       nutrient_object:
         range: Nutrient
         description: >-
@@ -396,6 +416,9 @@ classes:
         description: >-
           The name of a type of relationship between the
           nutrient and the anatomical part or system.
+          Choose from one of the following:
+          "affects", "participates in".
+          If none of these apply, use "associated with".
       anatomy:
         range: Anatomy
         description: >-
@@ -414,8 +437,11 @@ classes:
         range: Relationship
         description: >-
           The name of a type of relationship between the
-          nutrient and the food or supplement. This is
-          usually "nutrient of".
+          nutrient and the food or supplement.
+          Choose from one of the following:
+          "nutrient of", "is active ingredient of",
+          "food component of".
+          If none of these apply, use "associated with".
       source:
         range: FoodOrSupplement
         description: >-

--- a/src/ontogpt/templates/mic.yaml
+++ b/src/ontogpt/templates/mic.yaml
@@ -52,9 +52,9 @@ classes:
             It may also include phenotypes such as an observable
             physical or behavioral trait or symptom (e.g., fever,
             headache, short attention span, petechiae,
-            telangiectasia). Phenotypes do NOT include high-level
-            biological processes such as "Insulin signaling" or "lipid
-            metabolism", developmental processes such as "limb development",
+            telangiectasia). Do NOT include relationships concerning only 
+            biological processes (e.g., "Insulin signaling" or "lipid
+            metabolism"), developmental processes such as "limb development",
             or health states such as "healthy teeth".
             Provide the full text from the input text describing the relationship
             without changes or summarization. Include all numbered inline
@@ -212,8 +212,9 @@ classes:
       minerals.
     id_prefixes:
       - CHEBI
+      - FOODON
     annotations:
-      annotators: sqlite:obo:chebi
+      annotators: sqlite:obo:chebi, sqlite:obo:foodon
       prompt: >-
         The name of a nutrient, including vitamins and
         minerals.
@@ -226,12 +227,14 @@ classes:
     id_prefixes:
       - MONDO
       - HP
+      - EFO # For traits
     annotations:
-      annotators: sqlite:obo:mondo, sqlite:obo:hp
+      annotators: sqlite:obo:mondo, sqlite:obo:hp, sqlite:obo:efo
       prompt: >-
         The name of a biological feature. This may
         include diseases, symptoms, abnormalities, or
-        other health statuses.
+        other health statuses, as well as observable
+        properties of an organism, such as body weight.
 
   BiologicalProcess:
     is_a: NamedEntity
@@ -285,6 +288,9 @@ classes:
           associated with cancer" would be
           "True" and "Vitamin A is associated
           with cancer" would be "False".
+          Statements characterized as "clinically insignificant",
+          "not clinically significant", or "not statistically significant"
+          should also be considered negated.
       context:
         range: string
         description: >-
@@ -332,6 +338,9 @@ classes:
         range: Feature
         description: >-
           The name of the biological feature defined in the claim.
+          This may need to be processed to a single term, e.g., 
+          the phrase "proteolysis (degradation) of insulin and some downstream 
+          effectors" is too long, but "insulin degradation" is acceptable.
     comments:
       - a Chemical to Feature relationship
 

--- a/src/ontogpt/templates/mic.yaml
+++ b/src/ontogpt/templates/mic.yaml
@@ -69,8 +69,9 @@ classes:
             Use the same description of the relationship as in the input text.
             For example, if the input text states "Iron supplementation
             was shown to successfully treat anemia (5,6)", the output should be
-            "Iron supplementation treats anemia (5,6)". Other potential
-            relationships include "ameliorates" or "prevents".
+            "Iron supplementation treats anemia (5,6)".
+            Do not assign a relationship type. Retain the language used in the
+            source text.
           prompt.examples: >-
             Evidence suggests that high-dose Vitamin A treatment may prevent Systemic Lupus Erythematosus (5,6). Further studies confirmed this finding (7); Studies have shown that Vitamin A is associated with bone cancer (8).
       nutrient_to_biological_process_relationships:
@@ -104,9 +105,9 @@ classes:
             Use the same description of the relationship as in the input text.
             For example, if the input text states "Vitamin A is a participant in
             Insulin Signaling (5,6)", the output should be
-            "Vitamin A participates in Insulin Signaling (5,6)". Other potential
-            relationships include "is input of", "is output of", "catalyzes",
-            "is substrate of", "involved in", and "enables". 
+            "Vitamin A participates in Insulin Signaling (5,6)".
+            Do not assign a relationship type. Retain the language used in the
+            source text.
           prompt.examples: >-
             There is a relationship between Vitamin A and Insulin Signaling (5). This relationship was confirmed in additional studies (6).
       nutrient_to_health_status_relationships:
@@ -140,8 +141,9 @@ classes:
             Use the same description of the relationship as in the input text.
             For example, if the input text states "Vitamin A levels are
             necessary for healthy teeth (5,6)", the output should be
-            "Vitamin A participates in the health of teeth (5,6)". Other potential
-            relationships include "ameliorates" or "prevents".
+            "Vitamin A participates in the health of teeth (5,6)".
+            Do not assign a relationship type. Retain the language used in the
+            source text.
           prompt.examples: >-
             There is a relationship between Vitamin A and Teeth (5). This relationship was confirmed in additional studies (6).
       nutrient_to_source_relationships:
@@ -219,7 +221,8 @@ classes:
   Feature:
     is_a: NamedEntity
     description: >-
-      The name of a biological feature.
+      The name of a biological feature or health status,
+      such as a disease, symptom, or abnormality.
     id_prefixes:
       - MONDO
       - HP


### PR DESCRIPTION
The main change here is to combine the relationship classes for nutrient + disease and nutrient + phenotype into a single relationship type, now in the slot `nutrient_to_feature_relationships`. 
Also various prompt engineering tweaks throughout, including some explicit suggestions of appropriate Biolink predicates.