### PR TITLE
Update drug template

### DIFF
--- a/src/ontogpt/templates/drug.py
+++ b/src/ontogpt/templates/drug.py
@@ -287,7 +287,7 @@ class DrugMechanism(ConfiguredBaseModel):
          'examples': [{'value': 'ibuprofen'},
                       {'value': 'Lipitor'},
                       {'value': 'sertraline'}]} })
-    mechanism_links: Optional[list[MechanismLink]] = Field(default=None, description="""A semicolon-separated list of mechanistic links that explain how the drug works. Each link should be a triple connecting two biological entities via a relationship type, such as 'drug inhibits enzyme' or 'protein activates pathway'.""", json_schema_extra = { "linkml_meta": {'alias': 'mechanism_links',
+    mechanism_links: Optional[list[MechanismLink]] = Field(default=None, description="""A semicolon-separated list of mechanistic links that explain how the drug works. This should only be based on the information explicitly mentioned in the text. Each link should be a triple connecting two biological entities via a relationship type, such as 'drug inhibits enzyme' or 'protein activates pathway'.""", json_schema_extra = { "linkml_meta": {'alias': 'mechanism_links',
          'annotations': {'prompt.examples': {'tag': 'prompt.examples',
                                              'value': 'ibuprofen inhibits COX-2; COX-2 '
                                                       'involved in inflammatory '

--- a/src/ontogpt/templates/drug.py
+++ b/src/ontogpt/templates/drug.py
@@ -279,7 +279,7 @@ class DrugMechanismSet(ConfiguredBaseModel):
 class DrugMechanism(ConfiguredBaseModel):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/drug'})
 
-    disease: Optional[str] = Field(default=None, description="""The name of the disease or condition that is treated by the drug. This should be a specific disease entity rather than a general symptom.""", json_schema_extra = { "linkml_meta": {'alias': 'disease',
+    disease: Optional[str] = Field(default=None, description="""The name of the disease or condition that is treated by the drug. This should be a specific disease entity rather than a general symptom. Omit any qualifiers such as \"chronic\" or \"acute\" unless they are part of the disease name itself.""", json_schema_extra = { "linkml_meta": {'alias': 'disease',
          'domain_of': ['DrugMechanism'],
          'examples': [{'value': 'Alzheimer disease'},
                       {'value': 'hypertension'},

--- a/src/ontogpt/templates/drug.py
+++ b/src/ontogpt/templates/drug.py
@@ -289,7 +289,7 @@ class DrugMechanism(ConfiguredBaseModel):
          'examples': [{'value': 'ibuprofen'},
                       {'value': 'Lipitor'},
                       {'value': 'sertraline'}]} })
-    mechanism_links: Optional[list[MechanismLink]] = Field(default=None, description="""A semicolon-separated list of mechanistic links that explain how the drug works. This should only be based on the information explicitly mentioned in the text. Each link should be a triple connecting two biological entities via a relationship type, such as 'drug inhibits enzyme' or 'protein activates pathway'.""", json_schema_extra = { "linkml_meta": {'alias': 'mechanism_links',
+    mechanism_links: Optional[list[MechanismLink]] = Field(default=None, description="""A semicolon-separated list of mechanistic links that explain how the drug works. This should only be based on the information explicitly mentioned in the text. Each link should be a triple connecting two biological entities via a relationship type. For example, this may be between a drug and a protein, a protein and a pathway, or a protein and another protein. Refer to each by the name used in the text.""", json_schema_extra = { "linkml_meta": {'alias': 'mechanism_links',
          'annotations': {'prompt.examples': {'tag': 'prompt.examples',
                                              'value': 'ibuprofen inhibits COX-2; COX-2 '
                                                       'involved in inflammatory '

--- a/src/ontogpt/templates/drug.py
+++ b/src/ontogpt/templates/drug.py
@@ -1,186 +1,492 @@
-from __future__ import annotations
-from datetime import datetime, date
-from enum import Enum
+from __future__ import annotations 
 
-from typing import List, Dict, Optional, Any, Union
-from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
 import re
 import sys
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from decimal import Decimal 
+from enum import Enum 
+from typing import (
+    Any,
+    ClassVar,
+    Literal,
+    Optional,
+    Union
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator
+)
 
 
 metamodel_version = "None"
 version = "None"
 
+
 class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(
-        validate_assignment=True,
-        validate_default=True,
-        extra = 'forbid',
-        arbitrary_types_allowed=True,
-        use_enum_values = True)
+        validate_assignment = True,
+        validate_default = True,
+        extra = "forbid",
+        arbitrary_types_allowed = True,
+        use_enum_values = True,
+        strict = False,
+    )
     pass
 
 
-class NullDataOptions(str, Enum):
-    
-    
-    UNSPECIFIED_METHOD_OF_ADMINISTRATION = "UNSPECIFIED_METHOD_OF_ADMINISTRATION"
-    
-    NOT_APPLICABLE = "NOT_APPLICABLE"
-    
-    NOT_MENTIONED = "NOT_MENTIONED"
-    
-    
 
-class DrugMechanism(ConfiguredBaseModel):
-    
-    disease: Optional[str] = Field(None, description="""the name of the disease that is treated""")
-    drug: Optional[str] = Field(None, description="""the name of the drug that treats the disease""")
-    mechanism_links: Optional[List[MechanismLink]] = Field(default_factory=list, description="""semicolon-separated list of links, where each link is a triple connecting two entities via a relationship type""")
-    references: Optional[List[str]] = Field(default_factory=list)
-    source_text: Optional[str] = Field(None)
-    
-    
+
+class LinkMLMeta(RootModel):
+    root: dict[str, Any] = {}
+    model_config = ConfigDict(frozen=True)
+
+    def __getattr__(self, key:str):
+        return getattr(self.root, key)
+
+    def __getitem__(self, key:str):
+        return self.root[key]
+
+    def __setitem__(self, key:str, value):
+        self.root[key] = value
+
+    def __contains__(self, key:str) -> bool:
+        return key in self.root
+
+
+linkml_meta = LinkMLMeta({'default_prefix': 'drug',
+     'default_range': 'string',
+     'description': 'A template for extracting information about drug mechanisms '
+                    'of action, including the diseases they treat, the drugs '
+                    'themselves, and the detailed mechanistic pathways by which '
+                    'drugs produce their therapeutic effects. This template '
+                    'captures subject-predicate-object relationships that describe '
+                    'how drugs interact with biological entities to achieve '
+                    'therapeutic outcomes.',
+     'id': 'http://w3id.org/ontogpt/drug',
+     'imports': ['linkml:types', 'core'],
+     'license': 'https://creativecommons.org/publicdomain/zero/1.0/',
+     'name': 'drug',
+     'prefixes': {'BIOLINK': {'prefix_prefix': 'BIOLINK',
+                              'prefix_reference': 'https://w3id.org/biolink/vocab/'},
+                  'CHEBI': {'prefix_prefix': 'CHEBI',
+                            'prefix_reference': 'http://purl.obolibrary.org/obo/CHEBI_'},
+                  'CL': {'prefix_prefix': 'CL',
+                         'prefix_reference': 'http://purl.obolibrary.org/obo/CL_'},
+                  'DRUGBANK': {'prefix_prefix': 'DRUGBANK',
+                               'prefix_reference': 'https://go.drugbank.com/drugs/'},
+                  'HGNC': {'prefix_prefix': 'HGNC',
+                           'prefix_reference': 'http://identifiers.org/hgnc/'},
+                  'MESH': {'prefix_prefix': 'MESH',
+                           'prefix_reference': 'http://identifiers.org/mesh/'},
+                  'MONDO': {'prefix_prefix': 'MONDO',
+                            'prefix_reference': 'http://purl.obolibrary.org/obo/MONDO_'},
+                  'PR': {'prefix_prefix': 'PR',
+                         'prefix_reference': 'http://purl.obolibrary.org/obo/PR_'},
+                  'RO': {'prefix_prefix': 'RO',
+                         'prefix_reference': 'http://purl.obolibrary.org/obo/RO_'},
+                  'UBERON': {'prefix_prefix': 'UBERON',
+                             'prefix_reference': 'http://purl.obolibrary.org/obo/UBERON_'},
+                  'drug': {'prefix_prefix': 'drug',
+                           'prefix_reference': 'http://w3id.org/ontogpt/drug/'},
+                  'linkml': {'prefix_prefix': 'linkml',
+                             'prefix_reference': 'https://w3id.org/linkml/'},
+                  'rdf': {'prefix_prefix': 'rdf',
+                          'prefix_reference': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'}},
+     'source_file': 'src/ontogpt/templates/drug.yaml',
+     'title': 'Drug Mechanism Template'} )
+
+class NullDataOptions(str, Enum):
+    UNSPECIFIED_METHOD_OF_ADMINISTRATION = "UNSPECIFIED_METHOD_OF_ADMINISTRATION"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    NOT_MENTIONED = "NOT_MENTIONED"
+
+
 
 class ExtractionResult(ConfiguredBaseModel):
     """
     A result of extracting knowledge on text
     """
-    input_id: Optional[str] = Field(None)
-    input_title: Optional[str] = Field(None)
-    input_text: Optional[str] = Field(None)
-    raw_completion_output: Optional[str] = Field(None)
-    prompt: Optional[str] = Field(None)
-    extracted_object: Optional[Any] = Field(None, description="""The complex objects extracted from the text""")
-    named_entities: Optional[List[Any]] = Field(default_factory=list, description="""Named entities extracted from the text""")
-    
-    
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/core'})
+
+    input_id: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'input_id', 'domain_of': ['ExtractionResult']} })
+    input_title: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'input_title', 'domain_of': ['ExtractionResult']} })
+    input_text: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'input_text', 'domain_of': ['ExtractionResult']} })
+    raw_completion_output: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'raw_completion_output', 'domain_of': ['ExtractionResult']} })
+    prompt: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'prompt', 'domain_of': ['ExtractionResult']} })
+    extracted_object: Optional[Any] = Field(default=None, description="""The complex objects extracted from the text""", json_schema_extra = { "linkml_meta": {'alias': 'extracted_object', 'domain_of': ['ExtractionResult']} })
+    named_entities: Optional[list[Any]] = Field(default=None, description="""Named entities extracted from the text""", json_schema_extra = { "linkml_meta": {'alias': 'named_entities', 'domain_of': ['ExtractionResult']} })
+
 
 class NamedEntity(ConfiguredBaseModel):
-    
-    id: str = Field(..., description="""A unique identifier for the named entity""")
-    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
-    
-    
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'http://w3id.org/ontogpt/core'})
 
-class MechanismElement(NamedEntity):
-    
-    id: str = Field(..., description="""A unique identifier for the named entity""")
-    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
-    
-    
+    id: str = Field(default=..., description="""A unique identifier for the named entity""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['this is populated during the grounding and normalization step'],
+         'domain_of': ['NamedEntity', 'Publication']} })
+    label: Optional[str] = Field(default=None, description="""The label (name) of the named thing""", json_schema_extra = { "linkml_meta": {'alias': 'label',
+         'aliases': ['name'],
+         'annotations': {'owl': {'tag': 'owl',
+                                 'value': 'AnnotationProperty, AnnotationAssertion'}},
+         'domain_of': ['NamedEntity'],
+         'slot_uri': 'rdfs:label'} })
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['This is determined during grounding and normalization',
+                      'But is based on the full input text'],
+         'domain_of': ['NamedEntity']} })
 
-class Disease(NamedEntity):
-    
-    id: str = Field(..., description="""A unique identifier for the named entity""")
-    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
-    
-    
+    @field_validator('original_spans')
+    def pattern_original_spans(cls, v):
+        pattern=re.compile(r"^\d+:\d+$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
+        return v
 
-class Drug(NamedEntity):
-    
-    id: str = Field(..., description="""A unique identifier for the named entity""")
-    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
-    
-    
-
-class Predicate(NamedEntity):
-    
-    id: str = Field(..., description="""A unique identifier for the named entity""")
-    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
-    
-    
 
 class CompoundExpression(ConfiguredBaseModel):
-    
-    None
-    
-    
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'http://w3id.org/ontogpt/core'})
 
-class MechanismLink(CompoundExpression):
-    
-    subject: Optional[str] = Field(None)
-    predicate: Optional[str] = Field(None)
-    object: Optional[str] = Field(None)
-    
-    
+    pass
+
 
 class Triple(CompoundExpression):
     """
     Abstract parent for Relation Extraction tasks
     """
-    subject: Optional[str] = Field(None)
-    predicate: Optional[str] = Field(None)
-    object: Optional[str] = Field(None)
-    qualifier: Optional[str] = Field(None, description="""A qualifier for the statements, e.g. \"NOT\" for negation""")
-    subject_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""")
-    object_qualifier: Optional[str] = Field(None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""")
-    
-    
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'http://w3id.org/ontogpt/core'})
+
+    subject: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'subject', 'domain_of': ['Triple', 'MechanismLink']} })
+    predicate: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'predicate', 'domain_of': ['Triple', 'MechanismLink']} })
+    object: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'object', 'domain_of': ['Triple', 'MechanismLink']} })
+    qualifier: Optional[str] = Field(default=None, description="""A qualifier for the statements, e.g. \"NOT\" for negation""", json_schema_extra = { "linkml_meta": {'alias': 'qualifier', 'domain_of': ['Triple']} })
+    subject_qualifier: Optional[str] = Field(default=None, description="""An optional qualifier or modifier for the subject of the statement, e.g. \"high dose\" or \"intravenously administered\"""", json_schema_extra = { "linkml_meta": {'alias': 'subject_qualifier', 'domain_of': ['Triple']} })
+    object_qualifier: Optional[str] = Field(default=None, description="""An optional qualifier or modifier for the object of the statement, e.g. \"severe\" or \"with additional complications\"""", json_schema_extra = { "linkml_meta": {'alias': 'object_qualifier', 'domain_of': ['Triple']} })
+
 
 class TextWithTriples(ConfiguredBaseModel):
     """
     A text containing one or more relations of the Triple type.
     """
-    publication: Optional[Publication] = Field(None)
-    triples: Optional[List[Triple]] = Field(default_factory=list)
-    
-    
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/core'})
+
+    publication: Optional[Publication] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'publication',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'domain_of': ['TextWithTriples', 'TextWithEntity']} })
+    triples: Optional[list[Triple]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'triples', 'domain_of': ['TextWithTriples']} })
+
 
 class TextWithEntity(ConfiguredBaseModel):
     """
     A text containing one or more instances of a single type of entity.
     """
-    publication: Optional[Publication] = Field(None)
-    entities: Optional[List[str]] = Field(default_factory=list)
-    
-    
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/core'})
+
+    publication: Optional[Publication] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'publication',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'domain_of': ['TextWithTriples', 'TextWithEntity']} })
+    entities: Optional[list[str]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'entities', 'domain_of': ['TextWithEntity']} })
+
 
 class RelationshipType(NamedEntity):
-    
-    id: str = Field(..., description="""A unique identifier for the named entity""")
-    label: Optional[str] = Field(None, description="""The label (name) of the named thing""")
-    
-    
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/core',
+         'id_prefixes': ['RO', 'biolink']})
+
+    id: str = Field(default=..., description="""A unique identifier for the named entity""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['this is populated during the grounding and normalization step'],
+         'domain_of': ['NamedEntity', 'Publication']} })
+    label: Optional[str] = Field(default=None, description="""The label (name) of the named thing""", json_schema_extra = { "linkml_meta": {'alias': 'label',
+         'aliases': ['name'],
+         'annotations': {'owl': {'tag': 'owl',
+                                 'value': 'AnnotationProperty, AnnotationAssertion'}},
+         'domain_of': ['NamedEntity'],
+         'slot_uri': 'rdfs:label'} })
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['This is determined during grounding and normalization',
+                      'But is based on the full input text'],
+         'domain_of': ['NamedEntity']} })
+
+    @field_validator('original_spans')
+    def pattern_original_spans(cls, v):
+        pattern=re.compile(r"^\d+:\d+$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
+        return v
+
 
 class Publication(ConfiguredBaseModel):
-    
-    id: Optional[str] = Field(None, description="""The publication identifier""")
-    title: Optional[str] = Field(None, description="""The title of the publication""")
-    abstract: Optional[str] = Field(None, description="""The abstract of the publication""")
-    combined_text: Optional[str] = Field(None)
-    full_text: Optional[str] = Field(None, description="""The full text of the publication""")
-    
-    
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/core'})
+
+    id: Optional[str] = Field(default=None, description="""The publication identifier""", json_schema_extra = { "linkml_meta": {'alias': 'id', 'domain_of': ['NamedEntity', 'Publication']} })
+    title: Optional[str] = Field(default=None, description="""The title of the publication""", json_schema_extra = { "linkml_meta": {'alias': 'title', 'domain_of': ['Publication']} })
+    abstract: Optional[str] = Field(default=None, description="""The abstract of the publication""", json_schema_extra = { "linkml_meta": {'alias': 'abstract', 'domain_of': ['Publication']} })
+    combined_text: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'combined_text', 'domain_of': ['Publication']} })
+    full_text: Optional[str] = Field(default=None, description="""The full text of the publication""", json_schema_extra = { "linkml_meta": {'alias': 'full_text', 'domain_of': ['Publication']} })
+
 
 class AnnotatorResult(ConfiguredBaseModel):
-    
-    subject_text: Optional[str] = Field(None)
-    object_id: Optional[str] = Field(None)
-    object_text: Optional[str] = Field(None)
-    
-    
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/core'})
+
+    subject_text: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'subject_text', 'domain_of': ['AnnotatorResult']} })
+    object_id: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'object_id', 'domain_of': ['AnnotatorResult']} })
+    object_text: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'object_text', 'domain_of': ['AnnotatorResult']} })
+
+
+class DrugMechanismSet(ConfiguredBaseModel):
+    """
+    A collection of one or more drug mechanisms of action, each describing how a specific drug treats a particular disease through a series of mechanistic links.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/drug', 'tree_root': True})
+
+    drug_mechanisms: Optional[list[DrugMechanism]] = Field(default=None, description="""A semicolon-delimited list of individual drug mechanisms of action included in this set. Include all details regarding the drug, disease, and specific proteins or pathways involved, but only those explicitly mentioned in the text. If a drug is involved in multiple mechanisms for the same or different diseases, each mechanism should be represented as a separate entry. If a drug is mentioned without a disease or a disease without a drug, this should still be captured as a mechanism without the missing element.""", json_schema_extra = { "linkml_meta": {'alias': 'drug_mechanisms',
+         'annotations': {'prompt.examples': {'tag': 'prompt.examples',
+                                             'value': 'ibuprofen inhibits COX-2, an '
+                                                      'enzyme involved in '
+                                                      'inflammation; Lipitor inhibits '
+                                                      'HMGCR; sertraline is used to '
+                                                      'treat major depressive disorder '
+                                                      'and sertraline inhibits SLC6A4; '
+                                                      'Omeprazole inhibits ATP4A, '
+                                                      'reducing stomach acid '
+                                                      'production; Metformin'}},
+         'domain_of': ['DrugMechanismSet']} })
+
+
+class DrugMechanism(ConfiguredBaseModel):
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/drug'})
+
+    disease: Optional[str] = Field(default=None, description="""The name of the disease or condition that is treated by the drug. This should be a specific disease entity rather than a general symptom.""", json_schema_extra = { "linkml_meta": {'alias': 'disease',
+         'domain_of': ['DrugMechanism'],
+         'examples': [{'value': 'Alzheimer disease'},
+                      {'value': 'hypertension'},
+                      {'value': 'major depressive disorder'}]} })
+    drug: Optional[str] = Field(default=None, description="""The name of the pharmaceutical drug, medication, or therapeutic compound This can include brand names, generic names, or chemical compound names.""", json_schema_extra = { "linkml_meta": {'alias': 'drug',
+         'domain_of': ['DrugMechanism'],
+         'examples': [{'value': 'ibuprofen'},
+                      {'value': 'Lipitor'},
+                      {'value': 'sertraline'}]} })
+    mechanism_links: Optional[list[MechanismLink]] = Field(default=None, description="""A semicolon-separated list of mechanistic links that explain how the drug works. Each link should be a triple connecting two biological entities via a relationship type, such as 'drug inhibits enzyme' or 'protein activates pathway'.""", json_schema_extra = { "linkml_meta": {'alias': 'mechanism_links',
+         'annotations': {'prompt.examples': {'tag': 'prompt.examples',
+                                             'value': 'ibuprofen inhibits COX-2; COX-2 '
+                                                      'involved in inflammatory '
+                                                      'response'}},
+         'domain_of': ['DrugMechanism']} })
+    references: Optional[list[str]] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'references',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'domain_of': ['DrugMechanism']} })
+    source_text: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'source_text',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'domain_of': ['DrugMechanism']} })
+
+
+class MechanismElement(NamedEntity):
+    """
+    A biological entity that participates in a drug mechanism of action. This can include genes, proteins, enzymes, receptors, pathways,  cellular components, or other molecular entities.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'annotators': {'tag': 'annotators',
+                                        'value': 'sqlite:obo:go, sqlite:obo:mesh, '
+                                                 'sqlite:obo:uberon, sqlite:obo:pr, '
+                                                 'sqlite:obo:cl'}},
+         'from_schema': 'http://w3id.org/ontogpt/drug',
+         'id_prefixes': ['HGNC', 'MESH', 'UBERON', 'PR', 'CL']})
+
+    id: str = Field(default=..., description="""A unique identifier for the named entity""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['this is populated during the grounding and normalization step'],
+         'domain_of': ['NamedEntity', 'Publication']} })
+    label: Optional[str] = Field(default=None, description="""The label (name) of the named thing""", json_schema_extra = { "linkml_meta": {'alias': 'label',
+         'aliases': ['name'],
+         'annotations': {'owl': {'tag': 'owl',
+                                 'value': 'AnnotationProperty, AnnotationAssertion'}},
+         'domain_of': ['NamedEntity'],
+         'slot_uri': 'rdfs:label'} })
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['This is determined during grounding and normalization',
+                      'But is based on the full input text'],
+         'domain_of': ['NamedEntity']} })
+
+    @field_validator('original_spans')
+    def pattern_original_spans(cls, v):
+        pattern=re.compile(r"^\d+:\d+$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class Disease(NamedEntity):
+    """
+    A disease, disorder, condition, or pathological state that can be treated with pharmaceutical interventions. This includes both acute and chronic conditions, mental health disorders, and other medical conditions.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'annotators': {'tag': 'annotators',
+                                        'value': 'sqlite:obo:mesh, sqlite:obo:mondo'}},
+         'from_schema': 'http://w3id.org/ontogpt/drug',
+         'id_prefixes': ['MESH', 'MONDO']})
+
+    id: str = Field(default=..., description="""A unique identifier for the named entity""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['this is populated during the grounding and normalization step'],
+         'domain_of': ['NamedEntity', 'Publication']} })
+    label: Optional[str] = Field(default=None, description="""The label (name) of the named thing""", json_schema_extra = { "linkml_meta": {'alias': 'label',
+         'aliases': ['name'],
+         'annotations': {'owl': {'tag': 'owl',
+                                 'value': 'AnnotationProperty, AnnotationAssertion'}},
+         'domain_of': ['NamedEntity'],
+         'slot_uri': 'rdfs:label'} })
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['This is determined during grounding and normalization',
+                      'But is based on the full input text'],
+         'domain_of': ['NamedEntity']} })
+
+    @field_validator('original_spans')
+    def pattern_original_spans(cls, v):
+        pattern=re.compile(r"^\d+:\d+$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class Drug(NamedEntity):
+    """
+    A pharmaceutical drug, medication, therapeutic compound, or other chemical substance used for medical treatment. This includes prescription drugs, over-the-counter medications, biologics, and experimental therapeutics.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'annotators': {'tag': 'annotators',
+                                        'value': 'sqlite:obo:drugbank, '
+                                                 'sqlite:obo:chebi, sqlite:obo:mesh'}},
+         'from_schema': 'http://w3id.org/ontogpt/drug',
+         'id_prefixes': ['DRUGBANK', 'CHEBI', 'MESH']})
+
+    id: str = Field(default=..., description="""A unique identifier for the named entity""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['this is populated during the grounding and normalization step'],
+         'domain_of': ['NamedEntity', 'Publication']} })
+    label: Optional[str] = Field(default=None, description="""The label (name) of the named thing""", json_schema_extra = { "linkml_meta": {'alias': 'label',
+         'aliases': ['name'],
+         'annotations': {'owl': {'tag': 'owl',
+                                 'value': 'AnnotationProperty, AnnotationAssertion'}},
+         'domain_of': ['NamedEntity'],
+         'slot_uri': 'rdfs:label'} })
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['This is determined during grounding and normalization',
+                      'But is based on the full input text'],
+         'domain_of': ['NamedEntity']} })
+
+    @field_validator('original_spans')
+    def pattern_original_spans(cls, v):
+        pattern=re.compile(r"^\d+:\d+$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class Predicate(NamedEntity):
+    """
+    A relationship type that describes how two biological entities interact in the context of a drug mechanism. Examples include 'inhibits', 'activates', 'binds_to', 'regulates', or 'involved_in'.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'annotators': {'tag': 'annotators',
+                                        'value': 'sqlite:obo:biolink, sqlite:obo:ro'}},
+         'from_schema': 'http://w3id.org/ontogpt/drug',
+         'id_prefixes': ['RO', 'BIOLINK']})
+
+    id: str = Field(default=..., description="""A unique identifier for the named entity""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['this is populated during the grounding and normalization step'],
+         'domain_of': ['NamedEntity', 'Publication']} })
+    label: Optional[str] = Field(default=None, description="""The label (name) of the named thing""", json_schema_extra = { "linkml_meta": {'alias': 'label',
+         'aliases': ['name'],
+         'annotations': {'owl': {'tag': 'owl',
+                                 'value': 'AnnotationProperty, AnnotationAssertion'}},
+         'domain_of': ['NamedEntity'],
+         'slot_uri': 'rdfs:label'} })
+    original_spans: Optional[list[str]] = Field(default=None, description="""The coordinates of the original text span from which the named entity was extracted, inclusive. For example, \"10:25\" means the span starting from the 10th character and ending with the 25th character. The first character in the text has index 0. Newlines are treated as single characters. Multivalued as there may be multiple spans for a single text.""", json_schema_extra = { "linkml_meta": {'alias': 'original_spans',
+         'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},
+         'comments': ['This is determined during grounding and normalization',
+                      'But is based on the full input text'],
+         'domain_of': ['NamedEntity']} })
+
+    @field_validator('original_spans')
+    def pattern_original_spans(cls, v):
+        pattern=re.compile(r"^\d+:\d+$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid original_spans format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid original_spans format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class MechanismLink(CompoundExpression):
+    """
+    A mechanistic relationship that connects two biological entities through a specific relationship type, forming a subject-predicate-object triple. This represents one step or component in the overall mechanism of how a drug produces its therapeutic effect.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'http://w3id.org/ontogpt/drug'})
+
+    subject: Optional[str] = Field(default=None, description="""the source biological entity in the mechanistic relationship. This is typically the entity that performs or initiates the action.""", json_schema_extra = { "linkml_meta": {'alias': 'subject', 'domain_of': ['Triple', 'MechanismLink']} })
+    predicate: Optional[str] = Field(default=None, description="""the type of relationship or interaction between the subject and object. This describes how the subject entity affects or relates to the object entity.""", json_schema_extra = { "linkml_meta": {'alias': 'predicate', 'domain_of': ['Triple', 'MechanismLink']} })
+    object: Optional[str] = Field(default=None, description="""the target biological entity in the mechanistic relationship. This is typically the entity that is affected by or receives the action.""", json_schema_extra = { "linkml_meta": {'alias': 'object', 'domain_of': ['Triple', 'MechanismLink']} })
 
 
 # Model rebuild
 # see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
-DrugMechanism.model_rebuild()
 ExtractionResult.model_rebuild()
 NamedEntity.model_rebuild()
-MechanismElement.model_rebuild()
-Disease.model_rebuild()
-Drug.model_rebuild()
-Predicate.model_rebuild()
 CompoundExpression.model_rebuild()
-MechanismLink.model_rebuild()
 Triple.model_rebuild()
 TextWithTriples.model_rebuild()
 TextWithEntity.model_rebuild()
 RelationshipType.model_rebuild()
 Publication.model_rebuild()
 AnnotatorResult.model_rebuild()
+DrugMechanismSet.model_rebuild()
+DrugMechanism.model_rebuild()
+MechanismElement.model_rebuild()
+Disease.model_rebuild()
+Drug.model_rebuild()
+Predicate.model_rebuild()
+MechanismLink.model_rebuild()
 

--- a/src/ontogpt/templates/drug.py
+++ b/src/ontogpt/templates/drug.py
@@ -86,6 +86,8 @@ linkml_meta = LinkMLMeta({'default_prefix': 'drug',
                            'prefix_reference': 'http://identifiers.org/hgnc/'},
                   'MESH': {'prefix_prefix': 'MESH',
                            'prefix_reference': 'http://identifiers.org/mesh/'},
+                  'MI': {'prefix_prefix': 'MI',
+                         'prefix_reference': 'http://purl.obolibrary.org/obo/MI_'},
                   'MONDO': {'prefix_prefix': 'MONDO',
                             'prefix_reference': 'http://purl.obolibrary.org/obo/MONDO_'},
                   'PR': {'prefix_prefix': 'PR',
@@ -426,9 +428,10 @@ class Predicate(NamedEntity):
     A relationship type that describes how two biological entities interact in the context of a drug mechanism. Examples include 'inhibits', 'activates', 'binds_to', 'regulates', or 'involved_in'.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'annotators': {'tag': 'annotators',
-                                        'value': 'sqlite:obo:biolink, sqlite:obo:ro'}},
+                                        'value': 'sqlite:obo:biolink, sqlite:obo:mi, '
+                                                 'sqlite:obo:ro'}},
          'from_schema': 'http://w3id.org/ontogpt/drug',
-         'id_prefixes': ['RO', 'BIOLINK']})
+         'id_prefixes': ['RO', 'MI', 'BIOLINK']})
 
     id: str = Field(default=..., description="""A unique identifier for the named entity""", json_schema_extra = { "linkml_meta": {'alias': 'id',
          'annotations': {'prompt.skip': {'tag': 'prompt.skip', 'value': 'true'}},

--- a/src/ontogpt/templates/drug.yaml
+++ b/src/ontogpt/templates/drug.yaml
@@ -80,8 +80,9 @@ classes:
         description: >-
           A semicolon-separated list of mechanistic links that explain how the drug works.
           This should only be based on the information explicitly mentioned in the text.
-          Each link should be a triple connecting two biological entities via a relationship type,
-          such as 'drug inhibits enzyme' or 'protein activates pathway'.
+          Each link should be a triple connecting two biological entities via a relationship type.
+          For example, this may be between a drug and a protein, a protein and a pathway,
+          or a protein and another protein. Refer to each by the name used in the text.
         multivalued: true
         range: MechanismLink
         annotations:

--- a/src/ontogpt/templates/drug.yaml
+++ b/src/ontogpt/templates/drug.yaml
@@ -1,8 +1,12 @@
 id: http://w3id.org/ontogpt/drug
 name: drug
-title: Drug Template
+title: Drug Mechanism Template
 description: >-
-  A template for Drugs and drug mechanism
+  A template for extracting information about drug mechanisms of action,
+  including the diseases they treat, the drugs themselves, and the detailed
+  mechanistic pathways by which drugs produce their therapeutic effects.
+  This template captures subject-predicate-object relationships that describe
+  how drugs interact with biological entities to achieve therapeutic outcomes.
 license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
@@ -23,15 +27,33 @@ classes:
     tree_root: true
     attributes:
       disease:
-        description: the name of the disease that is treated
+        description: >-
+          The name of the disease condition that is treated by the drug.
+          This should be a specific disease entity rather than a general symptom.
         range: Disease
+        examples:
+          - value: Alzheimer disease
+          - value: hypertension
+          - value: major depressive disorder
       drug:
-        description: the name of the drug that treats the disease
+        description: >-
+          the name of the pharmaceutical drug, medication, or therapeutic compound
+          that is used to treat the specified disease. This can include brand names,
+          generic names, or chemical compound names.
         range: Drug
+        examples:
+          - value: ibuprofen
+          - value: Lipitor
+          - value: sertraline
       mechanism_links:
-        description: semicolon-separated list of links, where each link is a triple connecting two entities via a relationship type
+        description: >-
+          semicolon-separated list of mechanistic links that explain how the drug works.
+          Each link should be a triple connecting two biological entities via a relationship type,
+          such as 'drug inhibits enzyme' or 'protein activates pathway'.
         multivalued: true
         range: MechanismLink
+        annotations:
+          prompt.examples: ibuprofen inhibits COX-2; COX-2 involved_in inflammatory response
       references:
         multivalued: true
         range: string
@@ -43,6 +65,10 @@ classes:
           prompt.skip: "true"
 
   MechanismElement:
+    description: >-
+      A biological entity that participates in a drug mechanism of action.
+      This can include genes, proteins, enzymes, receptors, pathways, 
+      cellular components, or other molecular entities.
     is_a: NamedEntity
     id_prefixes:
       - HGNC
@@ -51,27 +77,51 @@ classes:
       annotators: sqlite:obo:go, sqlite:obo:mesh, sqlite:obo:uberon, sqlite:obo:pr, sqlite:obo:ncbitaxon, sqlite:obo:cl
 
   Disease:
+    description: >-
+      A disease, disorder, condition, or pathological state that can be treated
+      with pharmaceutical interventions. This includes both acute and chronic conditions,
+      mental health disorders, and other medical conditions.
     is_a: NamedEntity
-    # TODO: make mondo primary; we use mesh for now for evaluating drugmechdb
     annotations:
       annotators: sqlite:obo:mesh, sqlite:obo:mondo
 
   Drug:
+    description: >-
+      A pharmaceutical drug, medication, therapeutic compound, or other chemical substance
+      used for medical treatment. This includes prescription drugs, over-the-counter medications,
+      biologics, and experimental therapeutics.
     is_a: NamedEntity
     annotations:
       annotators: sqlite:obo:drugbank, sqlite:obo:chebi, sqlite:obo:mesh
 
   Predicate:
+    description: >-
+      A relationship type that describes how two biological entities interact
+      in the context of a drug mechanism. Examples include 'inhibits', 'activates',
+      'binds_to', 'regulates', or 'involved_in'.
     is_a: NamedEntity
     annotations:
       annotators: sqlite:obo:biolink, sqlite:obo:ro
 
   MechanismLink:
+    description: >-
+      A mechanistic relationship that connects two biological entities through a specific
+      relationship type, forming a subject-predicate-object triple. This represents
+      one step or component in the overall mechanism of how a drug produces its therapeutic effect.
     is_a: CompoundExpression
     attributes:
       subject:
+        description: >-
+          the source biological entity in the mechanistic relationship.
+          This is typically the entity that performs or initiates the action.
         range: MechanismElement
       predicate:
+        description: >-
+          the type of relationship or interaction between the subject and object.
+          This describes how the subject entity affects or relates to the object entity.
         range: Predicate
       object:
+        description: >-
+          the target biological entity in the mechanistic relationship.
+          This is typically the entity that is affected by or receives the action.
         range: MechanismElement

--- a/src/ontogpt/templates/drug.yaml
+++ b/src/ontogpt/templates/drug.yaml
@@ -12,6 +12,14 @@ prefixes:
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   HGNC: http://identifiers.org/hgnc/
   MESH: http://identifiers.org/mesh/
+  UBERON: http://purl.obolibrary.org/obo/UBERON_
+  PR: http://purl.obolibrary.org/obo/PR_
+  CL: http://purl.obolibrary.org/obo/CL_
+  MONDO: http://purl.obolibrary.org/obo/MONDO_
+  DRUGBANK: https://go.drugbank.com/drugs/
+  CHEBI: http://purl.obolibrary.org/obo/CHEBI_
+  RO: http://purl.obolibrary.org/obo/RO_
+  BIOLINK: https://w3id.org/biolink/vocab/
   drug: http://w3id.org/ontogpt/drug/
   linkml: https://w3id.org/linkml/
 
@@ -51,7 +59,7 @@ classes:
     attributes:
       disease:
         description: >-
-          The name of the disease condition that is treated by the drug.
+          The name of the disease or condition that is treated by the drug.
           This should be a specific disease entity rather than a general symptom.
         range: Disease
         examples:
@@ -60,9 +68,8 @@ classes:
           - value: major depressive disorder
       drug:
         description: >-
-          the name of the pharmaceutical drug, medication, or therapeutic compound
-          that is used to treat the specified disease. This can include brand names,
-          generic names, or chemical compound names.
+          The name of the pharmaceutical drug, medication, or therapeutic compound
+          This can include brand names, generic names, or chemical compound names.
         range: Drug
         examples:
           - value: ibuprofen
@@ -70,13 +77,13 @@ classes:
           - value: sertraline
       mechanism_links:
         description: >-
-          semicolon-separated list of mechanistic links that explain how the drug works.
+          A semicolon-separated list of mechanistic links that explain how the drug works.
           Each link should be a triple connecting two biological entities via a relationship type,
           such as 'drug inhibits enzyme' or 'protein activates pathway'.
         multivalued: true
         range: MechanismLink
         annotations:
-          prompt.examples: ibuprofen inhibits COX-2; COX-2 involved_in inflammatory response
+          prompt.examples: ibuprofen inhibits COX-2; COX-2 involved in inflammatory response
       references:
         multivalued: true
         range: string
@@ -96,8 +103,11 @@ classes:
     id_prefixes:
       - HGNC
       - MESH
+      - UBERON
+      - PR
+      - CL
     annotations:
-      annotators: sqlite:obo:go, sqlite:obo:mesh, sqlite:obo:uberon, sqlite:obo:pr, sqlite:obo:ncbitaxon, sqlite:obo:cl
+      annotators: sqlite:obo:go, sqlite:obo:mesh, sqlite:obo:uberon, sqlite:obo:pr, sqlite:obo:cl
 
   Disease:
     description: >-
@@ -105,6 +115,9 @@ classes:
       with pharmaceutical interventions. This includes both acute and chronic conditions,
       mental health disorders, and other medical conditions.
     is_a: NamedEntity
+    id_prefixes:
+      - MESH
+      - MONDO
     annotations:
       annotators: sqlite:obo:mesh, sqlite:obo:mondo
 
@@ -114,6 +127,10 @@ classes:
       used for medical treatment. This includes prescription drugs, over-the-counter medications,
       biologics, and experimental therapeutics.
     is_a: NamedEntity
+    id_prefixes:
+      - DRUGBANK
+      - CHEBI
+      - MESH
     annotations:
       annotators: sqlite:obo:drugbank, sqlite:obo:chebi, sqlite:obo:mesh
 
@@ -123,6 +140,9 @@ classes:
       in the context of a drug mechanism. Examples include 'inhibits', 'activates',
       'binds_to', 'regulates', or 'involved_in'.
     is_a: NamedEntity
+    id_prefixes:
+      - RO
+      - BIOLINK
     annotations:
       annotators: sqlite:obo:biolink, sqlite:obo:ro
 

--- a/src/ontogpt/templates/drug.yaml
+++ b/src/ontogpt/templates/drug.yaml
@@ -62,6 +62,8 @@ classes:
         description: >-
           The name of the disease or condition that is treated by the drug.
           This should be a specific disease entity rather than a general symptom.
+          Omit any qualifiers such as "chronic" or "acute" unless they are part of
+          the disease name itself.
         range: Disease
         examples:
           - value: Alzheimer disease

--- a/src/ontogpt/templates/drug.yaml
+++ b/src/ontogpt/templates/drug.yaml
@@ -78,6 +78,7 @@ classes:
       mechanism_links:
         description: >-
           A semicolon-separated list of mechanistic links that explain how the drug works.
+          This should only be based on the information explicitly mentioned in the text.
           Each link should be a triple connecting two biological entities via a relationship type,
           such as 'drug inhibits enzyme' or 'protein activates pathway'.
         multivalued: true

--- a/src/ontogpt/templates/drug.yaml
+++ b/src/ontogpt/templates/drug.yaml
@@ -20,6 +20,7 @@ prefixes:
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_
   RO: http://purl.obolibrary.org/obo/RO_
   BIOLINK: https://w3id.org/biolink/vocab/
+  MI: http://purl.obolibrary.org/obo/MI_
   drug: http://w3id.org/ontogpt/drug/
   linkml: https://w3id.org/linkml/
 
@@ -143,9 +144,10 @@ classes:
     is_a: NamedEntity
     id_prefixes:
       - RO
+      - MI
       - BIOLINK
     annotations:
-      annotators: sqlite:obo:biolink, sqlite:obo:ro
+      annotators: sqlite:obo:biolink, sqlite:obo:mi, sqlite:obo:ro
 
   MechanismLink:
     description: >-

--- a/src/ontogpt/templates/drug.yaml
+++ b/src/ontogpt/templates/drug.yaml
@@ -23,8 +23,31 @@ imports:
   - core
 
 classes:
-  DrugMechanism:
+
+  DrugMechanismSet:
+    description: >-
+      A collection of one or more drug mechanisms of action,
+      each describing how a specific drug treats a particular
+      disease through a series of mechanistic links.
     tree_root: true
+    attributes:
+      drug_mechanisms:
+        description: >-
+          A semicolon-delimited list of individual drug mechanisms
+          of action included in this set. Include all details regarding
+          the drug, disease, and specific proteins or pathways involved,
+          but only those explicitly mentioned in the text.
+          If a drug is involved in multiple mechanisms for the same or
+          different diseases, each mechanism should be represented as a
+          separate entry. If a drug is mentioned without a disease or a
+          disease without a drug, this should still be captured as a mechanism
+          without the missing element.
+        multivalued: true
+        range: DrugMechanism
+        annotations:
+          prompt.examples: ibuprofen inhibits COX-2, an enzyme involved in inflammation; Lipitor inhibits HMGCR; sertraline is used to treat major depressive disorder and sertraline inhibits SLC6A4; Omeprazole inhibits ATP4A, reducing stomach acid production; Metformin
+
+  DrugMechanism:
     attributes:
       disease:
         description: >-


### PR DESCRIPTION
Updates to the `drug` extraction template to allow for extraction of multiple sets of drug mechanisms, along with a variety of other improvements to descriptions, annotators, and prefixes.