### PR TITLE
Support current pyhornedowl in OWL exporter

### DIFF
--- a/src/ontogpt/engines/spires_engine.py
+++ b/src/ontogpt/engines/spires_engine.py
@@ -34,7 +34,7 @@ from ontogpt.engines.knowledge_engine import (
 from ontogpt.io.utils import read_text_with_fallbacks
 from ontogpt.io.yaml_wrapper import dump_minimal_yaml
 from ontogpt.templates.core import ExtractionResult, NamedEntity
-from ontogpt.utils.parse_utils import get_span_values, sanitize_text
+from ontogpt.utils.parse_utils import get_span_values, is_null_like_value, sanitize_text
 
 this_path = Path(__file__).parent
 
@@ -193,6 +193,13 @@ class SPIRESEngine(KnowledgeEngine):
     def _extract_from_text_to_dict(
         self, text: str, cls: Optional[ClassDefinition] = None
     ) -> RESPONSE_DICT:
+        # Placeholder values such as "none" or "N/A" are not real text to split
+        # into fields. Recursing on them wastes an LLM call and, because the model
+        # has nothing to extract, it often replies with a clarifying question that
+        # the parser then rejects ("does not contain a colon; ignoring").
+        if is_null_like_value(text):
+            logging.info(f"Skipping sub-extraction for null-like text: {text!r}")
+            return {}
         raw_text = self._raw_extract(text=text, cls=cls)
         return self._parse_response_to_dict(raw_text, cls)
 
@@ -627,7 +634,10 @@ class SPIRESEngine(KnowledgeEngine):
                             logging.info(f"Line '{line}' continuing from {continued_line}")
                             line = continued_line + ";" + line
                         if ":" not in line:
-                            logging.error(f"Line '{line}' does not contain a colon; ignoring")
+                            # Recoverable: the model returned a line we can't map
+                            # to a field (often a clarification/refusal during a
+                            # recursive sub-extraction). We skip it and continue.
+                            logging.warning(f"Line '{line}' does not contain a colon; ignoring")
                             continue
                     else:
                         # We made it this far but may still have a continued line
@@ -679,7 +689,10 @@ class SPIRESEngine(KnowledgeEngine):
             if field in cls_slots:
                 slot = sv.induced_slot(field, class_name)
         if not slot:
-            logging.error(f"Cannot find slot for {field} in {line}")
+            # Recoverable: the line's key doesn't match any slot of this class.
+            # This is expected when the model returns prose instead of fields
+            # (e.g. a refusal during recursion); we drop the line and continue.
+            logging.warning(f"Cannot find slot for {field} in {line}")
             return None
         if not val:
             msg = f"Empty value in key-value line: {line}"
@@ -711,6 +724,11 @@ class SPIRESEngine(KnowledgeEngine):
                 vals = [
                     self._extract_from_text_to_dict(v, slot_range) for v in vals  # type: ignore
                 ]
+                # Drop empty sub-extractions (e.g. from null-like placeholder values)
+                # so we don't emit empty inlined objects.
+                vals = [v for v in vals if v]
+                if not vals:
+                    return None
             else:
                 for sep in [" - ", ":", "/", "*", "-"]:
                     if all([sep in v for v in vals]):

--- a/src/ontogpt/io/owl_exporter.py
+++ b/src/ontogpt/io/owl_exporter.py
@@ -45,11 +45,25 @@ class OWLExporter(Exporter):
             for named_entity in extraction_output.named_entities:
                 ne_as_dc = self._as_dataclass_object(named_entity, schemaview)
                 doc = dumper.to_ontology_document(ne_as_dc, schemaview.schema)
-                axioms.extend(doc.ontology.axioms)
+                # Newer pyhornedowl returns a PyIndexedOntology directly from
+                # to_ontology_document(); older versions wrap it in `.ontology`.
+                ont = getattr(doc, "ontology", doc)
+                if hasattr(ont, "axioms"):
+                    axioms.extend(ont.axioms)
+                else:
+                    axioms.extend(ont.get_axioms())
         element_as_dataclass = self._as_dataclass_object(element, schemaview)
         doc = dumper.to_ontology_document(element_as_dataclass, schemaview.schema)
-        doc.ontology.axioms.extend(axioms)
-        output.write(str(doc))  # type: ignore
+        ont = getattr(doc, "ontology", doc)
+        if hasattr(ont, "axioms"):
+            ont.axioms.extend(axioms)
+            output.write(str(doc))  # type: ignore
+        else:
+            # PyIndexedOntology.get_axioms() yields AnnotatedComponent wrappers
+            # that add_axiom() won't accept, so unwrap to the inner component.
+            for ax in axioms:
+                ont.add_axiom(getattr(ax, "component", ax))
+            output.write(ont.save_to_string("owl"))  # type: ignore
 
     def _as_dataclass_object(self, element: pydantic.BaseModel, schemaview: SchemaView):
         cls_name = type(element).__name__

--- a/src/ontogpt/utils/parse_utils.py
+++ b/src/ontogpt/utils/parse_utils.py
@@ -49,8 +49,17 @@ def is_null_like_value(text: Optional[str]) -> bool:
     stripped = text.strip()
     if not stripped:
         return True
-    # Template echo, e.g. the model copies the prompt placeholder "<...>" back.
-    if stripped.startswith("<") and stripped.endswith(">"):
+    # Template echo: the model copies a prompt placeholder back verbatim. SPIRES
+    # builds these as "<{slot_prompt}>", where slot_prompt is always multi-word
+    # prose (e.g. "<the food item>", "<semicolon-separated list of foods>"), so a
+    # real echo always contains whitespace between the brackets. We require that
+    # whitespace so we don't eat genuine angle-bracketed values such as
+    # autolinked URLs or emails ("<https://example.com>", "<a@b.com>").
+    if (
+        stripped.startswith("<")
+        and stripped.endswith(">")
+        and any(c.isspace() for c in stripped[1:-1])
+    ):
         return True
     # Unwrap surrounding brackets/quotes/emphasis so "(none)" reads as "none".
     core = stripped.strip(_NULL_LIKE_WRAPPERS)

--- a/src/ontogpt/utils/parse_utils.py
+++ b/src/ontogpt/utils/parse_utils.py
@@ -5,6 +5,60 @@ import unicodedata
 from typing import List, Optional
 
 
+# Tokens an LLM commonly emits to mean "there is no value here". When one of
+# these is the *entire* value of a slot, it should be treated as absent rather
+# than as real text to recurse into or ground.
+_NULL_LIKE_TOKENS = frozenset(
+    {
+        "",
+        "none",
+        "n/a",
+        "na",
+        "n.a",
+        "null",
+        "nil",
+        "nan",
+        "unknown",
+        "unspecified",
+        "not specified",
+        "not applicable",
+        "not provided",
+        "none provided",
+        "no value",
+        "no value provided",
+    }
+)
+
+# Brackets, quotes, emphasis and trailing punctuation that models wrap around
+# placeholders, e.g. "(none)", "[N/A]", "*none*", "none.".
+_NULL_LIKE_WRAPPERS = "()[]{}\"'*` \t.,;:"
+
+
+def is_null_like_value(text: Optional[str]) -> bool:
+    """Return True if ``text``, as a whole, means "no value".
+
+    This matches empty/whitespace-only strings, common placeholder tokens
+    (e.g. "none", "N/A", "not specified"), the same tokens wrapped in brackets,
+    quotes or emphasis (e.g. "(none)", "*N/A*"), and template echoes that the LLM
+    sometimes returns verbatim (e.g. "<the food item>"). The match is on the
+    *entire* stripped value (case-insensitive), so legitimate values that merely
+    contain such a word (e.g. "non-fat milk") are not affected.
+    """
+    if text is None:
+        return True
+    stripped = text.strip()
+    if not stripped:
+        return True
+    # Template echo, e.g. the model copies the prompt placeholder "<...>" back.
+    if stripped.startswith("<") and stripped.endswith(">"):
+        return True
+    # Unwrap surrounding brackets/quotes/emphasis so "(none)" reads as "none".
+    core = stripped.strip(_NULL_LIKE_WRAPPERS)
+    if not core:
+        return True
+    return core.lower() in _NULL_LIKE_TOKENS
+
+
 def split_on_one_of(text: str, separators: List[str]) -> List[str]:
     """Split text on the first separator found."""
     for sep in separators:

--- a/tests/unit/test_utils/test_parse_utils.py
+++ b/tests/unit/test_utils/test_parse_utils.py
@@ -1,8 +1,8 @@
-"""Tests for parse_utils.sanitize_text."""
+"""Tests for parse_utils.sanitize_text and parse_utils.is_null_like_value."""
 
 import unittest
 
-from ontogpt.utils.parse_utils import sanitize_text
+from ontogpt.utils.parse_utils import is_null_like_value, sanitize_text
 
 
 class TestSanitizeText(unittest.TestCase):
@@ -32,6 +32,54 @@ class TestSanitizeText(unittest.TestCase):
         # After removal we expect the characters on either side
         # to be concatenated with existing space preserved
         self.assertEqual(sanitize_text(s), "A B")
+
+
+class TestIsNullLikeValue(unittest.TestCase):
+    def test_none_and_empty(self):
+        self.assertTrue(is_null_like_value(None))
+        self.assertTrue(is_null_like_value(""))
+        self.assertTrue(is_null_like_value("   "))
+
+    def test_placeholder_tokens(self):
+        for token in [
+            "none",
+            "None",
+            "N/A",
+            "n/a",
+            "NA",
+            "null",
+            "nil",
+            "NaN",
+            "unknown",
+            "unspecified",
+            "not specified",
+            "Not Applicable",
+            "none provided",
+            "no value",
+        ]:
+            self.assertTrue(is_null_like_value(token), f"expected {token!r} to be null-like")
+
+    def test_template_echo_is_null_like(self):
+        # The model sometimes echoes the prompt placeholder back verbatim.
+        self.assertTrue(is_null_like_value("<the food item>"))
+        self.assertTrue(is_null_like_value("<no url provided>"))
+
+    def test_wrapped_placeholders_are_null_like(self):
+        # Models wrap placeholders in brackets/quotes/emphasis or add trailing
+        # punctuation; these should still be treated as "no value".
+        for token in ["(none)", "[N/A]", "*none*", "none.", "'none'", "(None)", "{n/a}"]:
+            self.assertTrue(is_null_like_value(token), f"expected {token!r} to be null-like")
+
+    def test_real_values_are_not_null_like(self):
+        for value in [
+            "turkey",
+            "non-fat milk",  # contains "n/a" as a substring, but is a real value
+            "cooking spray",
+            "2 pounds",
+            "0",
+            "none of the above sauces",  # starts with "none" but is real text
+        ]:
+            self.assertFalse(is_null_like_value(value), f"expected {value!r} to be a real value")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/unit/test_utils/test_parse_utils.py
+++ b/tests/unit/test_utils/test_parse_utils.py
@@ -61,8 +61,18 @@ class TestIsNullLikeValue(unittest.TestCase):
 
     def test_template_echo_is_null_like(self):
         # The model sometimes echoes the prompt placeholder back verbatim.
+        # SPIRES placeholders are multi-word prose, so a real echo always has
+        # whitespace between the brackets.
         self.assertTrue(is_null_like_value("<the food item>"))
         self.assertTrue(is_null_like_value("<no url provided>"))
+        self.assertTrue(is_null_like_value("<semicolon-separated list of foods>"))
+
+    def test_angle_bracketed_real_values_are_not_null_like(self):
+        # Genuine values can arrive wrapped in angle brackets (e.g. a model
+        # autolinks a URL or email). These have no internal whitespace and must
+        # not be mistaken for a template-placeholder echo.
+        for value in ["<https://example.com>", "<a@b.com>", "<GO:0008150>"]:
+            self.assertFalse(is_null_like_value(value), f"expected {value!r} to be a real value")
 
     def test_wrapped_placeholders_are_null_like(self):
         # Models wrap placeholders in brackets/quotes/emphasis or add trailing


### PR DESCRIPTION
* Support current pyhornedowl in OWL exporter: Add compatibility with the latest pyhornedowl API and serialization behavior.
* Skip null-like placeholders in SPIRES recursion: Ignore placeholder values (e.g., "none", "N/A", "not specified") during nested extraction, reducing unnecessary LLM calls and noisy logs.